### PR TITLE
feat: add fallback language en-US

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -14,6 +14,9 @@
     "madeIn": "Entwickelt in Montréal, Québec 🇨🇦",
     "builtBy": "Erstellt von <author>Sebastien Castiel</author> und <source>Mitwirkenden</source>"
   },
+  "Support": {
+    "buttonLabel": "Unterstützen Sie uns"
+  },
   "Expenses": {
     "title": "Ausgaben",
     "description": "Hier sind die Ausgaben, die du für deine Gruppe erstellt hast.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "cmdk": "^0.2.0",
         "content-disposition": "^0.5.4",
         "dayjs": "^1.11.10",
+        "deepmerge": "^4.3.1",
         "embla-carousel-react": "^8.0.0-rc21",
         "feed": "^4.2.2",
         "lucide-react": "^0.290.0",
@@ -7216,6 +7217,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cmdk": "^0.2.0",
     "content-disposition": "^0.5.4",
     "dayjs": "^1.11.10",
+    "deepmerge": "^4.3.1",
     "embla-carousel-react": "^8.0.0-rc21",
     "feed": "^4.2.2",
     "lucide-react": "^0.290.0",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 import { getRequestConfig } from 'next-intl/server'
 import { getUserLocale } from './lib/locale'
+import deepmerge from 'deepmerge'
 
 export const localeLabels = {
   'en-US': 'English',
@@ -26,8 +27,12 @@ export const defaultLocale: Locale = 'en-US'
 export default getRequestConfig(async () => {
   const locale = await getUserLocale()
 
+  const userMessages = (await import(`../messages/${locale}.json`)).default
+  const defaultMessages = (await import(`../messages/en-US.json`)).default
+  const messages = deepmerge(defaultMessages, userMessages)
+
   return {
     locale,
-    messages: (await import(`../messages/${locale}.json`)).default,
+    messages,
   }
 })


### PR DESCRIPTION
As described in issue spliit-app/spliit#266, the translation for `Support.buttonLabel` is missing for the language fr-FR and also for several other languages.

This pull request implements the language en-US as fallback if the translation is missing based on the next-intl docs (https://next-intl.dev/docs/usage/configuration#messages-fallback) and adds the translation for de-DE as my native language is German.