### PR TITLE
Fix duplicate pageviews sent to Plausible on every re-render

### DIFF
--- a/src/app/groups/[groupId]/expenses/page.client.tsx
+++ b/src/app/groups/[groupId]/expenses/page.client.tsx
@@ -3,8 +3,8 @@
 import { ActiveUserModal } from '@/app/groups/[groupId]/expenses/active-user-modal'
 import { CreateFromReceiptButton } from '@/app/groups/[groupId]/expenses/create-from-receipt-button'
 import { ExpenseList } from '@/app/groups/[groupId]/expenses/expense-list'
-import { TrackPage } from '@/components/track-page'
 import ExportButton from '@/app/groups/[groupId]/export-button'
+import { TrackPage } from '@/components/track-page'
 import { Button } from '@/components/ui/button'
 import {
   Card,

--- a/src/components/track-page.tsx
+++ b/src/components/track-page.tsx
@@ -2,7 +2,7 @@
 
 import { usePlausible } from 'next-plausible'
 import { useSearchParams } from 'next/navigation'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useCallback, useEffect } from 'react'
 
 type Event =
   | { event: 'pageview'; props: {} }
@@ -51,12 +51,18 @@ function TrackPage_({ path }: Props) {
 export function useAnalytics() {
   const plausible = usePlausible()
 
-  const sendEvent = ({ event, props }: Event, path = '/') => {
-    const url = `${window.location.origin}${path}`
-    if (process.env.NODE_ENV !== 'production')
-      console.log('Analytics event:', event, props, url)
-    plausible(event, { props, u: url })
-  }
+  // Keep a stable identity: `TrackPage_` passes this to a `useEffect` dependency
+  // array, so a new function on every render would re-send the pageview on every
+  // re-render (and group pages re-render on every tRPC refetch).
+  const sendEvent = useCallback(
+    ({ event, props }: Event, path = '/') => {
+      const url = `${window.location.origin}${path}`
+      if (process.env.NODE_ENV !== 'production')
+        console.log('Analytics event:', event, props, url)
+      plausible(event, { props, u: url })
+    },
+    [plausible],
+  )
 
   return sendEvent
 }


### PR DESCRIPTION
## The bug

`useAnalytics()` returned a new `sendEvent` closure on every render. `TrackPage_` passes it into a `useEffect` dependency array:

```ts
useEffect(() => {
  sendEvent({ event: 'pageview', props: {} }, ...)
}, [path, ref, sendEvent])
```

So the dependency changed on every render, the effect re-ran on every render, and each run sent another **billable** pageview for the same URL and the same session.

Group pages re-render frequently:

1. `GroupLayoutClient` runs a tRPC `groups.get` query — mount, load, and any refetch. React Query is configured with `staleTime: 30s` and `refetchOnWindowFocus` is on by default, so every tab-back after half a minute counts.
2. `CurrentGroupProvider` receives `value={props}` built as a fresh object literal each render, so every consumer re-renders even when the group data is identical.
3. `TrackPage_` re-renders → new `sendEvent` → another pageview.

Minimum damage was 2 pageviews per group page load (loading → loaded). Everything past that came from refetches, which is why the inflation tracks dwell time.

## Evidence

From the Plausible day export for 2026-08-11 — routes that consume the group context vs. routes that don't:

| Route | Visitors | Pageviews | Per visitor | Consumes group context |
|---|---:|---:|---:|---|
| `/groups/[id]/expenses` | 564 | 3,192 | **5.7** | yes |
| `/groups/[id]/balances` | 250 | 1,248 | **5.0** | yes |
| `/groups` | 461 | 625 | 1.4 | no |
| `/` | 399 | 471 | 1.2 | no |
| `/blog`, `/blog/[slug]` | 44 | 57 | 1.3 | no |

Site-wide that day: 3,836 visits, 20,561 pageviews — 5.36 pageviews per visit, against only ~6 tracked routes.

## The fix

Wrap `sendEvent` in `useCallback` so it has a stable identity. The pageview then fires once per mount and on `path` / `ref` changes only. `usePlausible()` is already `useCallback`-stable, so this was the only unstable link in the chain.

Custom events are unaffected — they fire from submit handlers, not effects.

## Impact

- **Billing:** ~706k → ~350k billable events/month (projected from Aug 11). We're currently tracking toward the 1M plan cap; this restores roughly 3× headroom.
- **Data quality:** `views_per_visit` should drop from 5.36 to ~2, and bounce rate should rise to a truthful value. Visits and visitors are unaffected — they were always correct.

## Testing

- `npx tsc --noEmit` passes.
- Manual check after deploy: open a group page, tab away for 40s, tab back. Before this change a second `/api/event` beacon fires; after, none.

## Follow-ups (not in this PR)

- `CurrentGroupProvider` should `useMemo` its context value — free performance win across the group UI, no longer a billing issue once the tracker is stable.
- Consider sending a normalised path (`/groups/[id]/expenses`) instead of the real group id. The Pages report is currently 300+ single-group rows and unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yG7Up2kXdyx7B7JLBsVdT
