### PR TITLE
Strip group and expense IDs from everything sent to Plausible

### DIFF
--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -79,7 +79,7 @@ export function CreateFromReceiptButton() {
 }
 
 function ReceiptDialogContent() {
-  const { group, groupId } = useCurrentGroup()
+  const { group } = useCurrentGroup()
   const { data: categoriesData } = trpc.categories.list.useQuery()
   const categories = categoriesData?.categories
 
@@ -109,7 +109,7 @@ function ReceiptDialogContent() {
     }
 
     const upload = async () => {
-      sendEvent({ event: 'expense: scan receipt', props: { groupId } })
+      sendEvent({ event: 'expense: scan receipt', props: {} })
       try {
         setPending(true)
         console.log('Uploading image…')
@@ -252,7 +252,7 @@ function ReceiptDialogContent() {
             if (!receiptInfo || !group) return
             sendEvent({
               event: 'expense: create from receipt',
-              props: { groupId },
+              props: {},
             })
             router.push(
               `/groups/${group.id}/expenses/create?amount=${

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -276,15 +276,12 @@ export function ExpenseForm({
   const submit = async (values: ExpenseFormValues) => {
     if (expense) {
       sendEvent(
-        {
-          event: 'expense: update',
-          props: { groupId: group.id, expenseId: expense.id },
-        },
+        { event: 'expense: update', props: {} },
         `/groups/${group.id}/expenses`,
       )
     } else {
       sendEvent(
-        { event: 'expense: create', props: { groupId: group.id } },
+        { event: 'expense: create', props: {} },
         `/groups/${group.id}/expenses`,
       )
     }
@@ -1277,10 +1274,7 @@ export function ExpenseForm({
                     onDocumentAttached={() => {
                       sendEvent({
                         event: 'expense: attach document',
-                        props: {
-                          groupId: group.id,
-                          expenseId: expense?.id ?? null,
-                        },
+                        props: {},
                       })
                     }}
                   />
@@ -1299,10 +1293,7 @@ export function ExpenseForm({
             <DeletePopup
               onDelete={async () => {
                 sendEvent(
-                  {
-                    event: 'expense: delete',
-                    props: { groupId: group.id, expenseId: expense.id },
-                  },
+                  { event: 'expense: delete', props: {} },
                   `/groups/${group.id}/expenses`,
                 )
                 await onDelete(activeUserId ?? undefined)

--- a/src/app/groups/[groupId]/expenses/export-link.tsx
+++ b/src/app/groups/[groupId]/expenses/export-link.tsx
@@ -21,7 +21,7 @@ export const ExportLink = function ExportLink({
       prefetch={false}
       onClick={() => {
         sendEvent(
-          { event: 'group: export expenses', props: { groupId } },
+          { event: 'group: export expenses', props: {} },
           `/groups/${groupId}/expenses`,
         )
       }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NewsButton } from '@/components/news-button'
 import { ProgressBar } from '@/components/progress-bar'
 import { ThemeProvider } from '@/components/theme-provider'
 import { ThemeToggle } from '@/components/theme-toggle'
+import { TrackOutboundLinks } from '@/components/track-page'
 import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/toaster'
 import { env } from '@/lib/env'
@@ -235,11 +236,10 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       {env.PLAUSIBLE_DOMAIN && (
-        <PlausibleProvider
-          domain={env.PLAUSIBLE_DOMAIN}
-          trackOutboundLinks
-          manualPageviews
-        />
+        // Outbound links are tracked by `TrackOutboundLinks` rather than by
+        // Plausible's `trackOutboundLinks`, which would attach the raw URL of
+        // the current page — including the group ID.
+        <PlausibleProvider domain={env.PLAUSIBLE_DOMAIN} manualPageviews />
       )}
       <AxiomWebVitals />
       <ApplePwaSplash icon="/logo-with-text.png" color="#027756" />
@@ -254,6 +254,7 @@ export default async function RootLayout({
             <Suspense>
               <ProgressBar />
             </Suspense>
+            {env.PLAUSIBLE_DOMAIN && <TrackOutboundLinks />}
             <Content>{children}</Content>
           </ThemeProvider>
         </NextIntlClientProvider>

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -120,7 +120,7 @@ export function GroupForm({
         onSubmit={form.handleSubmit(async (values) => {
           if (group) {
             sendEvent(
-              { event: 'group: update', props: { groupId: group.id } },
+              { event: 'group: update', props: {} },
               `/groups/${group.id}/edit`,
             )
           } else {

--- a/src/components/track-page.tsx
+++ b/src/components/track-page.tsx
@@ -1,25 +1,32 @@
 'use client'
 
+import { anonymizePath } from '@/lib/anonymize-path'
 import { usePlausible } from 'next-plausible'
 import { useSearchParams } from 'next/navigation'
 import { Suspense, useCallback, useEffect } from 'react'
 
+/**
+ * No properties at all. `{}` would not do: it accepts any object, so it would
+ * silently let a `groupId` through.
+ */
+type NoProps = Record<string, never>
+
+// Group and expense IDs are deliberately absent from every event: they identify
+// a specific user's data, and they are unique per document, so they would only
+// ever produce single-visitor rows. Properties here must stay low-cardinality.
 type Event =
-  | { event: 'pageview'; props: {} }
-  | { event: 'group: create'; props: {} }
-  | { event: 'group: update'; props: { groupId: string } }
-  | { event: 'expense: create'; props: { groupId: string } }
-  | { event: 'expense: scan receipt'; props: { groupId: string } }
-  | { event: 'expense: create from receipt'; props: { groupId: string } }
-  | { event: 'expense: update'; props: { groupId: string; expenseId: string } }
-  | { event: 'expense: delete'; props: { groupId: string; expenseId: string } }
-  | { event: 'group: export expenses'; props: { groupId: string } }
-  | { event: 'news: open menu'; props: {} }
+  | { event: 'pageview'; props: NoProps }
+  | { event: 'group: create'; props: NoProps }
+  | { event: 'group: update'; props: NoProps }
+  | { event: 'expense: create'; props: NoProps }
+  | { event: 'expense: scan receipt'; props: NoProps }
+  | { event: 'expense: create from receipt'; props: NoProps }
+  | { event: 'expense: update'; props: NoProps }
+  | { event: 'expense: delete'; props: NoProps }
+  | { event: 'group: export expenses'; props: NoProps }
+  | { event: 'news: open menu'; props: NoProps }
   | { event: 'news: click news'; props: { news: string } }
-  | {
-      event: 'expense: attach document'
-      props: { groupId: string; expenseId: string | null }
-    }
+  | { event: 'expense: attach document'; props: NoProps }
 
 type Props = {
   path: string
@@ -56,7 +63,9 @@ export function useAnalytics() {
   // re-render (and group pages re-render on every tRPC refetch).
   const sendEvent = useCallback(
     ({ event, props }: Event, path = '/') => {
-      const url = `${window.location.origin}${path}`
+      // Anonymize here rather than at the call sites, so no caller can leak an
+      // ID by passing a path built from `groupId`.
+      const url = `${window.location.origin}${anonymizePath(path)}`
       if (process.env.NODE_ENV !== 'production')
         console.log('Analytics event:', event, props, url)
       plausible(event, { props, u: url })

--- a/src/components/track-page.tsx
+++ b/src/components/track-page.tsx
@@ -27,6 +27,8 @@ type Event =
   | { event: 'news: open menu'; props: NoProps }
   | { event: 'news: click news'; props: { news: string } }
   | { event: 'expense: attach document'; props: NoProps }
+  // Same name Plausible's built-in tracking used, so history stays comparable.
+  | { event: 'Outbound Link: Click'; props: { url: string } }
 
 type Props = {
   path: string
@@ -51,6 +53,47 @@ function TrackPage_({ path }: Props) {
       `${path}${ref ? `?ref=${ref}` : ''}`,
     )
   }, [path, ref, sendEvent])
+
+  return null
+}
+
+/**
+ * Replaces Plausible's built-in `trackOutboundLinks`. That one sends the event
+ * without a URL, so Plausible falls back to `location.href` — which on a group
+ * page carries the group ID. Sending it ourselves routes it through
+ * `useAnalytics`, which anonymizes the path.
+ *
+ * Only the pathname is reported: the expense creation route carries the title
+ * and amount in its query string, and those don't belong in analytics either.
+ */
+export function TrackOutboundLinks() {
+  const sendEvent = useAnalytics()
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      // Middle-click only, matching Plausible's own handler.
+      if (event.type === 'auxclick' && event.button !== 1) return
+      if (!(event.target instanceof Element)) return
+
+      const anchor = event.target.closest('a')
+      // `href` is not a string on SVG anchors, and `host` is empty for
+      // `mailto:` and `tel:` links.
+      if (typeof anchor?.href !== 'string') return
+      if (!anchor.host || anchor.host === window.location.host) return
+
+      sendEvent(
+        { event: 'Outbound Link: Click', props: { url: anchor.href } },
+        window.location.pathname,
+      )
+    }
+
+    document.addEventListener('click', handleClick)
+    document.addEventListener('auxclick', handleClick)
+    return () => {
+      document.removeEventListener('click', handleClick)
+      document.removeEventListener('auxclick', handleClick)
+    }
+  }, [sendEvent])
 
   return null
 }

--- a/src/lib/anonymize-path.test.ts
+++ b/src/lib/anonymize-path.test.ts
@@ -37,7 +37,10 @@ describe('anonymizePath', () => {
     ['/', '/'],
     ['/groups', '/groups'],
     ['/blog', '/blog'],
-    ['/blog/we-need-an-open-source-alternative', '/blog/we-need-an-open-source-alternative'],
+    [
+      '/blog/we-need-an-open-source-alternative',
+      '/blog/we-need-an-open-source-alternative',
+    ],
   ]
 
   test.each(cases)('%s → %s', (path, expected) => {

--- a/src/lib/anonymize-path.test.ts
+++ b/src/lib/anonymize-path.test.ts
@@ -1,34 +1,41 @@
 import { anonymizePath } from './anonymize-path'
 
+/**
+ * Made-up IDs, shaped like the real ones (21-character nanoid for groups, cuid
+ * for expenses). Never paste a real ID in here: this file is public.
+ */
+const GROUP_A = 'exampleGroupId0000000'
+const GROUP_B = 'anotherGroupId0000000'
+const GROUP_C = 'thirdGroupId000000000'
+const GROUP_D = 'fourthGroupId00000000'
+const EXPENSE = 'exampleExpenseId000000000'
+
 describe('anonymizePath', () => {
   const cases: [path: string, expected: string][] = [
     // Group IDs
-    ['/groups/gElKwDeZwPuBWR7zj4sr3', '/groups/[groupId]'],
-    ['/groups/gElKwDeZwPuBWR7zj4sr3/expenses', '/groups/[groupId]/expenses'],
-    ['/groups/52Xv_FFAu5Q1qm_ekbPT8/balances', '/groups/[groupId]/balances'],
-    ['/groups/Isf80VvaN2bBbWwSw3OqK/edit', '/groups/[groupId]/edit'],
-    ['/groups/9j4Exo1Khb4v8ynK4GPxt/stats', '/groups/[groupId]/stats'],
+    [`/groups/${GROUP_A}`, '/groups/[groupId]'],
+    [`/groups/${GROUP_A}/expenses`, '/groups/[groupId]/expenses'],
+    [`/groups/${GROUP_B}/balances`, '/groups/[groupId]/balances'],
+    [`/groups/${GROUP_C}/edit`, '/groups/[groupId]/edit'],
+    [`/groups/${GROUP_D}/stats`, '/groups/[groupId]/stats'],
 
     // Expense IDs
     [
-      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/cm5xk2p9r000108l3h1a2b3c4/edit',
+      `/groups/${GROUP_A}/expenses/${EXPENSE}/edit`,
       '/groups/[groupId]/expenses/[expenseId]/edit',
     ],
 
     // Static segments in an ID position are kept
     ['/groups/create', '/groups/create'],
+    [`/groups/${GROUP_A}/expenses/create`, '/groups/[groupId]/expenses/create'],
     [
-      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/create',
-      '/groups/[groupId]/expenses/create',
-    ],
-    [
-      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/export/csv',
+      `/groups/${GROUP_A}/expenses/export/csv`,
       '/groups/[groupId]/expenses/export/csv',
     ],
 
     // Query strings and hashes are preserved, and never scanned for IDs
     [
-      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses?ref=share',
+      `/groups/${GROUP_A}/expenses?ref=share`,
       '/groups/[groupId]/expenses?ref=share',
     ],
     ['/groups/create?ref=share', '/groups/create?ref=share'],
@@ -48,7 +55,7 @@ describe('anonymizePath', () => {
   })
 
   it('is idempotent', () => {
-    const once = anonymizePath('/groups/gElKwDeZwPuBWR7zj4sr3/expenses')
+    const once = anonymizePath(`/groups/${GROUP_A}/expenses`)
     expect(anonymizePath(once)).toBe(once)
   })
 })

--- a/src/lib/anonymize-path.test.ts
+++ b/src/lib/anonymize-path.test.ts
@@ -1,0 +1,51 @@
+import { anonymizePath } from './anonymize-path'
+
+describe('anonymizePath', () => {
+  const cases: [path: string, expected: string][] = [
+    // Group IDs
+    ['/groups/gElKwDeZwPuBWR7zj4sr3', '/groups/[groupId]'],
+    ['/groups/gElKwDeZwPuBWR7zj4sr3/expenses', '/groups/[groupId]/expenses'],
+    ['/groups/52Xv_FFAu5Q1qm_ekbPT8/balances', '/groups/[groupId]/balances'],
+    ['/groups/Isf80VvaN2bBbWwSw3OqK/edit', '/groups/[groupId]/edit'],
+    ['/groups/9j4Exo1Khb4v8ynK4GPxt/stats', '/groups/[groupId]/stats'],
+
+    // Expense IDs
+    [
+      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/cm5xk2p9r000108l3h1a2b3c4/edit',
+      '/groups/[groupId]/expenses/[expenseId]/edit',
+    ],
+
+    // Static segments in an ID position are kept
+    ['/groups/create', '/groups/create'],
+    [
+      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/create',
+      '/groups/[groupId]/expenses/create',
+    ],
+    [
+      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses/export/csv',
+      '/groups/[groupId]/expenses/export/csv',
+    ],
+
+    // Query strings and hashes are preserved, and never scanned for IDs
+    [
+      '/groups/gElKwDeZwPuBWR7zj4sr3/expenses?ref=share',
+      '/groups/[groupId]/expenses?ref=share',
+    ],
+    ['/groups/create?ref=share', '/groups/create?ref=share'],
+
+    // Paths without IDs are untouched
+    ['/', '/'],
+    ['/groups', '/groups'],
+    ['/blog', '/blog'],
+    ['/blog/we-need-an-open-source-alternative', '/blog/we-need-an-open-source-alternative'],
+  ]
+
+  test.each(cases)('%s → %s', (path, expected) => {
+    expect(anonymizePath(path)).toBe(expected)
+  })
+
+  it('is idempotent', () => {
+    const once = anonymizePath('/groups/gElKwDeZwPuBWR7zj4sr3/expenses')
+    expect(anonymizePath(once)).toBe(once)
+  })
+})

--- a/src/lib/anonymize-path.ts
+++ b/src/lib/anonymize-path.ts
@@ -1,0 +1,33 @@
+/**
+ * Segments that follow `/groups/` or `/expenses/` without being an identifier.
+ * Everything else in that position is a group or expense ID.
+ */
+const GROUP_ROUTES = new Set(['create'])
+const EXPENSE_ROUTES = new Set(['create', 'export'])
+
+/**
+ * Replaces group and expense IDs in a path with placeholders, so they are never
+ * sent to analytics. Those IDs are the capability to read someone's group, and
+ * they are unique per document, which also turns the pages report into thousands
+ * of one-visitor rows.
+ *
+ * `/groups/gElKwDeZwPuBWR7zj4sr3/expenses` → `/groups/[groupId]/expenses`
+ */
+export function anonymizePath(path: string): string {
+  const [pathname, ...rest] = path.split(/(?=[?#])/)
+  const segments = pathname.split('/')
+
+  return (
+    segments
+      .map((segment, index) => {
+        if (!segment) return segment
+        const parent = segments[index - 1]
+        if (parent === 'groups' && !GROUP_ROUTES.has(segment))
+          return '[groupId]'
+        if (parent === 'expenses' && !EXPENSE_ROUTES.has(segment))
+          return '[expenseId]'
+        return segment
+      })
+      .join('/') + rest.join('')
+  )
+}

--- a/src/lib/anonymize-path.ts
+++ b/src/lib/anonymize-path.ts
@@ -11,7 +11,7 @@ const EXPENSE_ROUTES = new Set(['create', 'export'])
  * they are unique per document, which also turns the pages report into thousands
  * of one-visitor rows.
  *
- * `/groups/gElKwDeZwPuBWR7zj4sr3/expenses` → `/groups/[groupId]/expenses`
+ * `/groups/exampleGroupId0000000/expenses` → `/groups/[groupId]/expenses`
  */
 export function anonymizePath(path: string): string {
   const [pathname, ...rest] = path.split(/(?=[?#])/)


### PR DESCRIPTION
Follow-up to #21.

Group and expense IDs were leaving the app in three places. A group ID is the capability to read that group — anyone holding one can open it — so it doesn't belong in a third-party analytics service. The IDs are also unique per document, which is why the pages report is currently 300+ rows of one-visitor group URLs and the custom properties report is unusable.

## 1. Event properties

`groupId` and `expenseId` are removed from the `Event` union rather than filtered at runtime, so the compiler rejects any future attempt to attach one.

The union used `props: {}` — which accepts *any* object, so the IDs were passing the type check unnoticed. `Record<string, never>` actually rejects them:

```ts
type NoProps = Record<string, never>
```

That change alone surfaced all 8 call sites. `news: click news` keeps its `news` property: a news item slug is low-cardinality and identifies content, not a user.

## 2. Event URLs

Anonymized centrally in `useAnalytics`, not at the call sites, so no caller can leak an ID by building a path from `group.id`:

```
/groups/<21-char nanoid>/expenses  ->  /groups/[groupId]/expenses
```

`anonymizePath` keeps static segments that sit in an ID position (`/groups/create`, `/expenses/create`, `/expenses/export/csv`) and leaves query strings alone. 16 unit tests in `src/lib/anonymize-path.test.ts`.

## 3. Outbound link clicks

Plausible's `trackOutboundLinks` sends the click event *without* a URL, and its script then falls back to `location.href`:

```js
b.u = p && (p.u || p.url) || location.href
```

On a group page that's the real URL, group ID included — so 1 and 2 close every path except this one. `TrackOutboundLinks` replaces it with an equivalent passive listener routed through `useAnalytics`. It mirrors Plausible's own handler: middle-click only for `auxclick`, skips SVG anchors (whose `href` isn't a string) and `mailto:`/`tel:` links (no host), and never calls `preventDefault`, so navigation is untouched.

Only the pathname is reported, not the query string — the expense creation route carries the expense title and amount in its query, which don't belong in analytics either.

The event keeps the name `Outbound Link: Click`, so the existing goal and its history keep working.

## Effect on the dashboard

Event names and counts are unchanged, so historical data stays comparable. What changes:

- **Pages** collapses from 300+ single-visitor group URLs into `/groups/[groupId]/expenses` and `/groups/[groupId]/balances` — actually readable.
- **Custom properties** loses `groupId` / `expenseId`, which only ever produced single-visitor rows.
- Per-group numbers are no longer available. That's the intent.

## Not covered

`document.referrer`, which Plausible sends with every event. On a full page load out of a group page it holds that page's real URL. Not fixable from here; client-side navigation (nearly all in-app navigation) is unaffected, and Plausible discards same-host referrers when computing sources.

## Testing

- `npx jest` — 28 pass, 16 of them new.
- `npx tsc --noEmit` — clean.
- `npx eslint src` — 0 errors (17 pre-existing warnings).
- `npx prettier -c src` — clean.

Worth a manual check after deploy: click an outbound link (the footer's GitHub or LinkedIn links) from a group page and confirm the event arrives with `u` set to `/groups/[groupId]/expenses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yG7Up2kXdyx7B7JLBsVdT
