### PR TITLE
Open a PR for each new base release, with Claude resolving conflicts

### DIFF
--- a/.github/sync-base/CONFLICT_RESOLUTION.md
+++ b/.github/sync-base/CONFLICT_RESOLUTION.md
@@ -1,0 +1,176 @@
+# Resolving base-merge conflicts
+
+Context for whoever (human or Claude Code) resolves conflicts when merging a
+`spliit-app/spliit` release tag into `spliit-app/spliit-web`.
+
+`spliit-web` is the hosted build of Spliit. It is a **superset** of the base
+repo: everything upstream does, plus a marketing site, a blog, an email
+feedback flow, and privacy-conscious analytics. The base repo is not a
+dependency — it is the same tree, merged in periodically.
+
+## The one rule
+
+**Both sides survive.** A conflict here means upstream changed a line the fork
+also changed. Almost never is the right answer "take theirs" or "take ours"
+wholesale — it is "apply the upstream change to the fork's version of the
+code". If you genuinely cannot reconcile the two, say so in your summary
+rather than silently dropping one side.
+
+`README.md` is the single documented exception — see below.
+
+## `README.md` — always keep ours, entirely
+
+Upstream's README is the full project readme: features, stack, self-hosting,
+Docker, opt-in features, license. This fork replaced it with a five-line stub
+pointing contributors at `spliit-app/spliit`. Upstream edits its README almost
+every release, so **this file conflicts on nearly every sync**.
+
+Resolution is always the same:
+
+```sh
+git checkout --ours README.md && git add README.md
+```
+
+Do not merge upstream's sections in, and do not spend time reading the diff.
+The stub is deliberate: contributor-facing documentation lives in the base
+repo, and duplicating it here would only rot.
+
+## Invariant that must not regress
+
+**No group ID or expense ID may ever reach Plausible.** This was fixed
+deliberately in `Strip group and expense IDs from everything sent to Plausible`
+(#22). If an upstream change reintroduces an ID into an analytics event name,
+prop, or pageview URL, strip it during the merge and note it in your summary.
+High-cardinality identifiers also cost money on the Plausible plan.
+
+## Files the fork owns outright
+
+These do not exist upstream, so they should never conflict. If they do
+(upstream added a file with the same path), keep the fork's version and
+mention the collision.
+
+- `src/app/page.tsx` — the landing page. Fully rewritten by the fork; upstream's
+  version is a much smaller page.
+- `src/app/blog/**` — blog index, post pages, RSS/Atom feeds, OG images.
+- `src/app/privacy-policy/page.tsx`
+- `src/app/contributors.tsx`, `src/app/stats-display*.ts(x)`
+- `src/components/feedback-button/**`, `src/components/news-button.tsx`
+- `src/components/ui/accordion.tsx`
+- `src/lib/resend.ts`
+- `basehub.config.ts`, `basehub-types.d.ts` (the latter is generated — never
+  hand-edit it, and `git checkout --` it if a build regenerates it outside the
+  merge)
+
+## Files that diverge and will conflict
+
+### `src/lib/analytics/events.ts` — designed seam, respect it
+
+Upstream deliberately left a fork extension point here. It maintains the
+`BaseAnalyticsEvent` union; the fork fills in `CustomAnalyticsEvent`, which is
+`never` upstream:
+
+```ts
+type CustomAnalyticsEvent =
+  | { event: 'news: open menu'; props: NoProps }
+  | { event: 'news: click news'; props: { news: string } }
+```
+
+**Resolution:** take upstream's `BaseAnalyticsEvent` verbatim (they may have
+added events), keep the fork's `CustomAnalyticsEvent` verbatim. Keep the fork's
+doc comment. Do not merge the two unions into one.
+
+### `src/lib/hooks.ts`
+
+The fork adds `useLocalStorageState` and the `useCallback` import. Everything
+else is upstream's. Take upstream's changes, re-add the fork's hook and import.
+
+### `src/lib/env.ts`
+
+The fork adds four optional keys to `envSchema`: `FEEDBACK_EMAIL_FROM`,
+`FEEDBACK_EMAIL_TO`, `RESEND_API_KEY`, `STRIPE_DONATION_LINK`. Union of both
+side's keys. They are all optional or defaulted, so upstream deployments are
+unaffected.
+
+### `src/app/layout.tsx`
+
+Heavily reworked by the fork (extra nav, footer, analytics wiring, metadata).
+Start from the fork's version and port upstream's functional changes into it —
+new providers, i18n plumbing, script tags, `<head>` additions. Do not start
+from upstream's version and re-add the fork's UI; that loses too much.
+
+### `src/app/groups/layout.tsx`, `src/app/groups/[groupId]/group-header.tsx`, `src/app/globals.css`, `src/app/sitemap.ts`
+
+Small fork deltas over upstream code. Take upstream's change and re-apply the
+fork's delta on top. `sitemap.ts` in particular must keep the fork's blog and
+marketing routes.
+
+### `tsconfig.json`
+
+The fork appends `"basehub-types.d.ts"` and `"basehub.config.ts"` to `include`.
+Keep those entries alongside whatever upstream changed.
+
+### `package.json`
+
+Union of dependencies. Fork-only packages that must stay: `basehub`, `resend`,
+`@radix-ui/react-accordion`, and anything else the fork-owned files import.
+For a package both sides have, take the **higher** version. Keep upstream's
+script changes unless they conflict with a fork-only script.
+
+### `package-lock.json`
+
+**Never hand-merge this file.** Resolve `package.json` first, then:
+
+```sh
+npm install --package-lock-only
+npm install --ignore-scripts
+```
+
+Always pass `--ignore-scripts` to npm in CI: this repo's `postinstall` runs
+`prisma migrate deploy`, which needs a live database and will fail.
+
+A corrupted lockfile has broken `main` before (`fix: repair corrupted
+package-lock.json breaking CI on main`, #556), so verify `npm ci
+--ignore-scripts` succeeds afterwards.
+
+### `messages/*.json`
+
+Union of keys. Only `en-US.json` and `fi.json` currently carry fork-added
+strings; the other locales are untouched from upstream, so they should merge
+cleanly. Never drop an upstream-added key — a missing key breaks that locale at
+runtime. Keep the JSON valid and alphabetically consistent with its neighbours.
+
+### `.github/workflows/**`
+
+`ci.yml` and `cd.yml` are shared with upstream — take upstream's changes.
+`sync-base-release.yml` and everything under `.github/sync-base/` are fork-only
+and do not exist upstream. Note that merging a change to any workflow file
+requires the pushing token to hold the `workflow` permission; if the push step
+fails with a workflow-scope error, that is why (see `README.md` in this folder).
+
+### `prisma/**`
+
+Migrations are append-only. Keep **both** sides' migration directories; never
+renumber, rename, or delete an existing migration. For `schema.prisma`, union
+the model/field changes.
+
+## Verifying
+
+```sh
+npm run check-types
+npm run lint
+npm run check-formatting   # `npm run prettier` rewrites files in place
+```
+
+These are the same checks `ci.yml` runs, minus the build. `npx prisma generate`
+and `npx basehub` (needs `BASEHUB_TOKEN`) must have run first or type checking
+will fail on missing generated types.
+
+## Things never to do during a sync merge
+
+- Do not create or push git tags. `cd.yml` triggers on any tag push and would
+  publish a Docker image.
+- Do not `git merge --abort` or `git reset` — the automation needs the merge
+  left in progress.
+- Do not commit `basehub-types.d.ts` changes that came from regenerating it
+  rather than from the merge.
+- Do not "fix" unrelated pre-existing lint or type errors in the same commit.

--- a/.github/sync-base/README.md
+++ b/.github/sync-base/README.md
@@ -2,9 +2,9 @@
 
 `.github/workflows/sync-base-release.yml` keeps this fork in step with
 `spliit-app/spliit`. Once a day it checks upstream's latest GitHub release; if
-that tag is not already an ancestor of `main`, it creates `sync-base-<tag>`,
-merges the tag with `--no-ff`, has Claude Code resolve any conflicts, runs the
-CI checks, and opens a PR.
+that tag is not already an ancestor of `main` **and upstream CI is green for
+it**, it creates `sync-base-<tag>`, merges the tag with `--no-ff`, has Claude
+Code resolve any conflicts, runs the CI checks, and opens a PR.
 
 The PR branch contains a real merge commit (`Merge base <tag>`, two parents:
 fork `main` and the upstream tag), so once it lands the tag is part of this
@@ -61,6 +61,64 @@ Actions to create and approve pull requests**. Needed only for the
 
 The job is a no-op when the tag is already merged or `sync-base-<tag>` already
 exists on the remote, so re-running is safe.
+
+## The green-checks gate
+
+A release only produces a PR if upstream CI passed on the tagged commit.
+[`require-green-checks.sh`](require-green-checks.sh) enforces it and can be run
+by hand:
+
+```sh
+.github/sync-base/require-green-checks.sh spliit-app/spliit <commit-sha>
+# exit 0 green · 2 red · 3 still pending
+```
+
+The rules:
+
+- Every check run listed for `REQUIRED_CHECKS` (default `checks,e2e`) must
+  exist, be completed, and have concluded `success`. `skipped` does not count
+  for a check we explicitly demanded.
+- No other check run may have failed. `success`, `skipped` and `neutral` are
+  all fine; anything else is red.
+- If checks are still running — or a required one has not been reported yet —
+  the script waits (`CHECKS_TIMEOUT_SECONDS`, default 2700s, polled every 60s)
+  and then gives up. A pending release is not an error: the job stays green and
+  the next daily run picks it up.
+
+A red release logs a `::warning::` and opens no PR. Either way the check-run
+table is written to the workflow run's summary.
+
+### Why the tagged commit has the checks you want
+
+Upstream's `e2e.yml` triggers on `push: tags: ['*']`, the same trigger as
+`cd.yml` — so `e2e` is a genuine per-release gate and its check run attaches to
+the tag's commit. Release tags also sit on `main`, so `ci.yml`'s `checks` run
+is on the same commit. That is why a single commit SHA is enough to judge a
+release.
+
+> **Use the check-runs API, not `/status`.** These are GitHub Actions check
+> runs; the legacy combined-status endpoint reports `state: "pending"` with
+> zero statuses for the very same commit. A gate written against `/status`
+> would block every release forever.
+
+### Tuning and bypassing
+
+`REQUIRED_CHECKS` and `CHECKS_TIMEOUT_SECONDS` are set in the workflow's
+`Require green checks on the base release` step. `REQUIRED_CHECKS` is
+comma-separated, so a check whose name contains a comma — such as
+`build (linux/amd64, ubuntu-latest)` — cannot be listed. Those still count
+under the "nothing else may fail" rule.
+
+To merge a tag without the gate:
+
+```sh
+gh workflow run sync-base-release.yml -R spliit-app/spliit-web \
+  -f tag=1.15.0 -f skip_checks=true
+```
+
+Needed for backfilling old releases: tags from before the workflows existed
+have no check runs at all, so the gate correctly reports them as pending
+forever. The resulting PR is labelled as unverified in its body.
 
 ## What Claude Code is asked to do
 

--- a/.github/sync-base/README.md
+++ b/.github/sync-base/README.md
@@ -1,0 +1,109 @@
+# Base release sync
+
+`.github/workflows/sync-base-release.yml` keeps this fork in step with
+`spliit-app/spliit`. Once a day it checks upstream's latest GitHub release; if
+that tag is not already an ancestor of `main`, it creates `sync-base-<tag>`,
+merges the tag with `--no-ff`, has Claude Code resolve any conflicts, runs the
+CI checks, and opens a PR.
+
+The PR branch contains a real merge commit (`Merge base <tag>`, two parents:
+fork `main` and the upstream tag), so once it lands the tag is part of this
+fork's history and the next run correctly skips it. **Merge the PR with
+"Create a merge commit"** — squashing would flatten the merge and the
+already-merged check would never fire again for that tag.
+
+## Setup
+
+### 1. Secrets
+
+| Secret | Required | What it is |
+| --- | --- | --- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | one of the two | Run `claude setup-token` locally and paste the result. Bills to your Claude subscription. |
+| `ANTHROPIC_API_KEY` | one of the two | Alternative to the OAuth token. Bills to the API account. |
+| `SYNC_PAT` | recommended | Fine-grained PAT with **Contents: read & write**, **Pull requests: read & write**, and **Workflows: read & write** on `spliit-app/spliit-web`. |
+| `BASEHUB_TOKEN` | already set | Reused from `ci.yml` for the post-merge checks. |
+
+```sh
+gh secret set CLAUDE_CODE_OAUTH_TOKEN -R spliit-app/spliit-web
+gh secret set SYNC_PAT               -R spliit-app/spliit-web
+```
+
+Set exactly one of `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`; the
+workflow passes both inputs and whichever is empty is ignored.
+
+### Why `SYNC_PAT` matters
+
+Two reasons, both of which bite without it:
+
+1. **CI would not run on the sync PR.** GitHub deliberately does not trigger
+   workflows for events raised by `GITHUB_TOKEN`, so a PR opened with the
+   default token gets no `ci.yml` run — you would be reviewing a merge with no
+   signal beyond the workflow's own checks.
+2. **Pushes touching `.github/workflows/` are rejected.** If upstream changes a
+   workflow file, `GITHUB_TOKEN` cannot push that change. The PAT needs the
+   `workflow` permission for those merges to go through.
+
+The workflow falls back to `GITHUB_TOKEN` when `SYNC_PAT` is unset, so it still
+works — just with those two caveats.
+
+### 2. Allow Actions to open pull requests
+
+Settings → Actions → General → Workflow permissions → tick **Allow GitHub
+Actions to create and approve pull requests**. Needed only for the
+`GITHUB_TOKEN` fallback path; a PAT bypasses it.
+
+## Running it
+
+- **Scheduled:** daily at 06:00 UTC.
+- **Manually:** `gh workflow run sync-base-release.yml -R spliit-app/spliit-web`
+- **A specific tag** (backfill, or re-run after deleting a branch):
+  `gh workflow run sync-base-release.yml -R spliit-app/spliit-web -f tag=1.22.0`
+
+The job is a no-op when the tag is already merged or `sync-base-<tag>` already
+exists on the remote, so re-running is safe.
+
+## What Claude Code is asked to do
+
+Only when `git merge` reports conflicts. It gets the conflicted file list and
+is pointed at [`CONFLICT_RESOLUTION.md`](CONFLICT_RESOLUTION.md), which
+describes how this fork diverges from the base and which side wins where. It
+resolves and `git add`s files, regenerates the lockfile if needed, and runs
+`check-types` / `lint` / `check-formatting`. It is explicitly forbidden from
+committing, pushing, aborting the merge, or opening the PR — the workflow does
+all of that, so a bad resolution shows up as a reviewable diff rather than
+something already on a branch you did not see.
+
+After Claude runs, the workflow independently verifies that no unmerged paths
+and no conflict markers remain, and that the merge is still in progress. It
+fails loudly rather than committing a half-resolved tree.
+
+Model: `claude-opus-5`. Drop to `claude-sonnet-5` in the workflow's
+`claude_args` if you want cheaper runs; these merges are small in volume but
+the resolutions are subtle, so Opus is the default.
+
+## Reducing the delay (optional)
+
+Polling means up to a day between an upstream release and the PR. Both repos
+are under the same org, so if you want it immediate, add a workflow to
+`spliit-app/spliit` that pings this one:
+
+```yaml
+name: Notify fork of release
+on:
+  release:
+    types: [published]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.SPLIIT_WEB_DISPATCH_PAT }}
+        run: |
+          gh workflow run sync-base-release.yml \
+            -R spliit-app/spliit-web \
+            -f tag='${{ github.event.release.tag_name }}'
+```
+
+That needs a PAT with **Actions: read & write** on `spliit-web` stored in the
+*base* repo, and it puts fork-specific automation in the public upstream repo.
+The daily poll avoids both, which is why it is the default.

--- a/.github/sync-base/pr-checklist.md
+++ b/.github/sync-base/pr-checklist.md
@@ -1,0 +1,8 @@
+### Review checklist
+
+- [ ] Fork-only pages still intact (landing page, blog, privacy policy)
+- [ ] Analytics still strips group and expense IDs (`src/lib/analytics/events.ts`, `src/lib/hooks.ts`)
+- [ ] Feedback button and news button unaffected
+- [ ] `package-lock.json` was regenerated, not hand-merged
+- [ ] `prisma/migrations` kept both sides, nothing renumbered
+- [ ] Merge with **Create a merge commit** so the base tag stays in this fork's history

--- a/.github/sync-base/require-green-checks.sh
+++ b/.github/sync-base/require-green-checks.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Gate the base-release sync on upstream CI being green for the tagged commit.
+#
+#   require-green-checks.sh <owner/repo> <commit-sha>
+#
+# Exit codes:
+#   0  green    - every required check succeeded and nothing else failed
+#   2  red      - at least one check failed, or a required check was skipped
+#   3  pending  - checks are still running, or a required check has not
+#                 appeared yet; try again later
+#
+# Environment:
+#   REQUIRED_CHECKS         comma-separated check-run names that must exist and
+#                           succeed (default: "checks,e2e")
+#   CHECKS_TIMEOUT_SECONDS  how long to wait for pending checks (default: 2700)
+#   CHECKS_POLL_SECONDS     interval between polls (default: 60)
+#   GH_TOKEN                token for `gh api`
+#
+# Note: the tagged commit is the ref that upstream's `push: tags` workflows run
+# against, so cd.yml's build and e2e.yml's e2e both attach their check runs to
+# it, as does ci.yml via the push to main. Use the check-runs API, not the
+# legacy /status endpoint: GitHub Actions reports check runs, and /status
+# returns `pending` with zero statuses for these commits.
+
+set -euo pipefail
+
+REPO="${1:?usage: require-green-checks.sh <owner/repo> <commit-sha>}"
+SHA="${2:?usage: require-green-checks.sh <owner/repo> <commit-sha>}"
+
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-checks,e2e}"
+CHECKS_TIMEOUT_SECONDS="${CHECKS_TIMEOUT_SECONDS:-2700}"
+CHECKS_POLL_SECONDS="${CHECKS_POLL_SECONDS:-60}"
+
+# Conclusions that are acceptable for a check we did not explicitly require.
+# `skipped` and `neutral` are normal for conditional jobs; anything else that is
+# completed and not `success` counts as a failure.
+is_acceptable() {
+  case "$1" in
+    success | skipped | neutral) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+deadline=$(( $(date +%s) + CHECKS_TIMEOUT_SECONDS ))
+
+while :; do
+  # filter=latest collapses re-runs to the most recent attempt per check name.
+  runs="$(gh api --paginate \
+    "repos/${REPO}/commits/${SHA}/check-runs?filter=latest&per_page=100" \
+    --jq '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')"
+
+  # Plain strings rather than arrays: bash 3.2 errors on ${arr[@]} for an empty
+  # array under `set -u`, and this script is also run by hand on macOS.
+  failed=''
+  running=''
+  seen=0
+
+  if [ -n "${runs}" ]; then
+    while IFS=$'\t' read -r name status conclusion; do
+      [ -n "${name}" ] || continue
+      seen=$(( seen + 1 ))
+      if [ "${status}" != 'completed' ]; then
+        running="${running}${running:+, }${name} (${status})"
+      elif ! is_acceptable "${conclusion}"; then
+        failed="${failed}${failed:+, }${name} (${conclusion})"
+      fi
+    done <<< "${runs}"
+  fi
+
+  # A required check must exist, be completed, and have concluded `success` --
+  # `skipped` is not good enough for something we explicitly demanded.
+  # Split on commas via a here-string, not word splitting: check-run names
+  # contain spaces (e.g. "build (linux/amd64, ubuntu-latest)").
+  missing=''
+  while IFS= read -r req; do
+    req="$(printf '%s' "${req}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -n "${req}" ] || continue
+    found=''
+    if [ -n "${runs}" ]; then
+      while IFS=$'\t' read -r name status conclusion; do
+        [ "${name}" = "${req}" ] || continue
+        found='yes'
+        # An outright failure was already recorded by the scan above; the case
+        # only this loop can catch is a required check that was skipped or
+        # neutral, which is acceptable for a check we did not demand.
+        if [ "${status}" = 'completed' ] \
+          && [ "${conclusion}" != 'success' ] \
+          && is_acceptable "${conclusion}"; then
+          failed="${failed}${failed:+, }${req} (required but ${conclusion})"
+        fi
+      done <<< "${runs}"
+    fi
+    [ -n "${found}" ] || missing="${missing}${missing:+, }${req}"
+  done <<< "$(printf '%s' "${REQUIRED_CHECKS}" | tr ',' '\n')"
+
+  echo "--- check runs on ${REPO}@${SHA:0:7} ---"
+  if [ -n "${runs}" ]; then
+    printf '%s\n' "${runs}" | awk -F'\t' '{printf "  %-40s %s %s\n", $1, $2, $3}'
+  else
+    echo "  (none)"
+  fi
+
+  if [ -n "${failed}" ]; then
+    echo "RED: ${failed}"
+    exit 2
+  fi
+
+  if [ -z "${running}" ] && [ -z "${missing}" ]; then
+    echo "GREEN: ${seen} check run(s), required: ${REQUIRED_CHECKS}"
+    exit 0
+  fi
+
+  reason=''
+  [ -n "${running}" ] && reason="still running: ${running}"
+  if [ -n "${missing}" ]; then
+    [ -n "${reason}" ] && reason="${reason}; "
+    reason="${reason}required check not reported yet: ${missing}"
+  fi
+
+  now="$(date +%s)"
+  if [ "${now}" -ge "${deadline}" ]; then
+    echo "PENDING (gave up after ${CHECKS_TIMEOUT_SECONDS}s): ${reason}"
+    exit 3
+  fi
+
+  echo "waiting ${CHECKS_POLL_SECONDS}s - ${reason}"
+  sleep "${CHECKS_POLL_SECONDS}"
+done

--- a/.github/workflows/sync-base-release.yml
+++ b/.github/workflows/sync-base-release.yml
@@ -15,6 +15,11 @@ on:
         description: 'Base tag to merge (defaults to the latest base release)'
         required: false
         type: string
+      skip_checks:
+        description: 'Merge even if upstream CI is not green (for backfilling old tags)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: sync-base
@@ -64,7 +69,8 @@ jobs:
           # --no-tags keeps base tags out of this repo on purpose: pushing a tag
           # here would trigger cd.yml and publish a Docker image.
           git fetch --no-tags base "refs/tags/${TAG}"
-          BASE_SHA="$(git rev-parse FETCH_HEAD)"
+          # ^{commit} peels an annotated tag to the commit the check runs hang off.
+          BASE_SHA="$(git rev-parse "FETCH_HEAD^{commit}")"
           echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
 
           if git merge-base --is-ancestor "${BASE_SHA}" HEAD; then
@@ -81,15 +87,77 @@ jobs:
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Node.js
+      # Every step below keys off gate.outputs.proceed rather than check.outputs.skip:
+      # when this step does not run, the output is empty, so one condition covers
+      # both "already synced" and "upstream is not green".
+      - name: Require green checks on the base release
+        id: gate
         if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BASE_SHA: ${{ steps.check.outputs.base_sha }}
+          SKIP_CHECKS: ${{ inputs.skip_checks }}
+          # Must exist on the tagged commit and have concluded `success`.
+          # `checks` comes from upstream ci.yml, `e2e` from upstream e2e.yml
+          # (which triggers on `push: tags`, so it is a genuine release gate).
+          # Comma-separated, so names containing a comma cannot be listed here.
+          REQUIRED_CHECKS: 'checks,e2e'
+          # e2e.yml allows itself 40 minutes; wait a little longer than that.
+          CHECKS_TIMEOUT_SECONDS: '2700'
+          CHECKS_POLL_SECONDS: '60'
+        run: |
+          set -uo pipefail
+          if [ "${SKIP_CHECKS}" = 'true' ]; then
+            echo "::warning::skip_checks was set - merging ${TAG} without verifying upstream CI."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "verified=bypassed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # tee rather than command substitution: the script can poll for up to
+          # CHECKS_TIMEOUT_SECONDS, and its progress should stream into the log
+          # rather than appear all at once when it finishes.
+          bash .github/sync-base/require-green-checks.sh "${BASE_REPO}" "${BASE_SHA}" 2>&1 \
+            | tee "${RUNNER_TEMP}/gate.log"
+          rc="${PIPESTATUS[0]}"
+          out="$(cat "${RUNNER_TEMP}/gate.log")"
+          {
+            echo "## Base release ${TAG}"
+            echo
+            echo '```'
+            echo "${out}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "${rc}" in
+            0)
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              echo "verified=green" >> "$GITHUB_OUTPUT"
+              ;;
+            2)
+              echo "::warning::${TAG} has failing checks upstream - not opening a sync PR."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            3)
+              echo "::notice::${TAG} checks have not finished - will retry on the next run."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::require-green-checks.sh exited ${rc}"
+              exit 1
+              ;;
+          esac
+
+      - name: Set up Node.js
+        if: steps.gate.outputs.proceed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'npm'
 
       - name: Install dependencies
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         env:
           BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
         run: |
@@ -104,7 +172,7 @@ jobs:
 
       - name: Merge base tag
         id: merge
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           BRANCH: ${{ steps.tag.outputs.branch }}
@@ -130,7 +198,7 @@ jobs:
           fi
 
       - name: Resolve conflicts with Claude Code
-        if: steps.check.outputs.skip == 'false' && steps.merge.outputs.conflicts == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.merge.outputs.conflicts == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -177,7 +245,7 @@ jobs:
             resolved it, then the status of each verification command.
 
       - name: Verify the merge is complete
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         run: |
           set -euo pipefail
           if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
@@ -195,7 +263,7 @@ jobs:
           }
 
       - name: Create the merge commit
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
@@ -207,7 +275,7 @@ jobs:
 
       - name: Run checks
         id: checks
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         continue-on-error: true
         env:
           BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
@@ -228,7 +296,7 @@ jobs:
           exit "$status"
 
       - name: Push branch and open pull request
-        if: steps.check.outputs.skip == 'false'
+        if: steps.gate.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
@@ -236,9 +304,17 @@ jobs:
           CONFLICTS: ${{ steps.merge.outputs.conflicts }}
           CHECKS: ${{ steps.checks.outputs.result }}
           FILES: ${{ steps.merge.outputs.files }}
+          VERIFIED: ${{ steps.gate.outputs.verified }}
+          REQUIRED_CHECKS: 'checks,e2e'
         run: |
           set -euo pipefail
           git push origin "${BRANCH}"
+
+          if [ "${VERIFIED}" = 'green' ]; then
+            UPSTREAM_LINE="✅ Upstream CI green on the tagged commit (required: \`${REQUIRED_CHECKS}\`)."
+          else
+            UPSTREAM_LINE="⚠️ Upstream CI was **not** verified — this run was dispatched with \`skip_checks\`."
+          fi
 
           if [ "${CONFLICTS}" = 'true' ]; then
             CONFLICT_LINE="⚠️ **Conflicts were resolved by Claude Code** — review the merge commit carefully."
@@ -258,6 +334,7 @@ jobs:
           # which would terminate this YAML block scalar.
           {
             printf '%s\n\n' "Merges [\`${TAG}\`](https://github.com/${BASE_REPO}/releases/tag/${TAG}) from \`${BASE_REPO}\` into this fork."
+            printf '%s\n' "${UPSTREAM_LINE}"
             printf '%s\n' "${CONFLICT_LINE}"
             printf '%s\n\n' "${CHECK_LINE}"
             printf '%s\n\n' "### Conflicted files"

--- a/.github/workflows/sync-base-release.yml
+++ b/.github/workflows/sync-base-release.yml
@@ -1,0 +1,274 @@
+name: Sync base release
+
+# Watches spliit-app/spliit for new releases and opens a PR on this fork
+# containing a merge commit for the new tag. Conflicts are resolved by Claude
+# Code before the PR is opened.
+#
+# Setup and required secrets: .github/sync-base/README.md
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Base tag to merge (defaults to the latest base release)'
+        required: false
+        type: string
+
+concurrency:
+  group: sync-base
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  BASE_REPO: spliit-app/spliit
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Resolve base tag to merge
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG}" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="$(gh api "repos/${BASE_REPO}/releases/latest" --jq .tag_name)"
+          fi
+          echo "Base release to merge: ${TAG}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "branch=sync-base-${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether there is anything to do
+        id: check
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.tag.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git remote add base "https://github.com/${BASE_REPO}.git"
+          # --no-tags keeps base tags out of this repo on purpose: pushing a tag
+          # here would trigger cd.yml and publish a Docker image.
+          git fetch --no-tags base "refs/tags/${TAG}"
+          BASE_SHA="$(git rev-parse FETCH_HEAD)"
+          echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+
+          if git merge-base --is-ancestor "${BASE_SHA}" HEAD; then
+            echo "::notice::${TAG} is already merged into main - nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "::notice::Branch ${BRANCH} already exists on origin - nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        if: steps.check.outputs.skip == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check.outputs.skip == 'false'
+        env:
+          BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # --ignore-scripts skips postinstall, which runs `prisma migrate deploy`
+          # and needs a live database.
+          npm ci --ignore-scripts
+          npx prisma generate
+          npx basehub
+          # basehub-types.d.ts is tracked but generated; keep it out of the merge commit.
+          git checkout -- basehub-types.d.ts
+
+      - name: Merge base tag
+        id: merge
+        if: steps.check.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.tag.outputs.branch }}
+          BASE_SHA: ${{ steps.check.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "${BRANCH}"
+
+          if git merge --no-ff --no-commit "${BASE_SHA}"; then
+            echo "::notice::Merged ${TAG} with no conflicts."
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflicts=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'files<<SYNC_EOF'
+              git diff --name-only --diff-filter=U
+              echo 'SYNC_EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "::warning::Merge of ${TAG} has conflicts - handing off to Claude Code."
+            git diff --name-only --diff-filter=U
+          fi
+
+      - name: Resolve conflicts with Claude Code
+        if: steps.check.outputs.skip == 'false' && steps.merge.outputs.conflicts == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-opus-5
+            --max-turns 80
+            --allowedTools Read,Edit,Write,Glob,Grep,Bash
+          prompt: |
+            You are resolving merge conflicts in spliit-app/spliit-web, a fork of the
+            open-source spliit-app/spliit. A merge of upstream release ${{ steps.tag.outputs.tag }}
+            is in progress in the current working directory (MERGE_HEAD exists).
+
+            Conflicted files:
+            ${{ steps.merge.outputs.files }}
+
+            Read .github/sync-base/CONFLICT_RESOLUTION.md first. It describes how this
+            fork diverges from the base and which side to prefer for each area. Follow it.
+
+            Your job:
+            1. Resolve every conflict so that BOTH the upstream change and the fork's
+               customisations survive. Never resolve by wholesale discarding one side.
+               `git log`, `git show`, and `git diff` are available if you need to see
+               what each side was trying to do.
+            2. `git add` each file as you finish it. Leave no conflict markers behind.
+            3. If package.json or package-lock.json conflicted, do not hand-merge the
+               lockfile: resolve package.json, then run `npm install --package-lock-only`
+               to regenerate package-lock.json, then `npm install --ignore-scripts` so
+               node_modules matches. Always pass --ignore-scripts to npm: this repo's
+               postinstall runs `prisma migrate deploy`, which needs a live database.
+            4. Verify: `npm run check-types`, `npm run lint`, and `npm run check-formatting`
+               (use `npm run prettier` to fix formatting). Fix what you reasonably can.
+               If a failure needs a product decision, leave it and say so in your summary.
+            5. `git checkout -- basehub-types.d.ts` if you accidentally regenerate it and
+               it was not part of this merge.
+
+            Hard constraints:
+            - Do NOT run `git commit`, `git merge --abort`, `git reset`, `git push`, or
+              any `gh pr` command. The workflow commits and opens the PR after you finish.
+            - Do NOT change files that are not part of this merge.
+
+            Finish with a short summary: one line per conflicted file explaining how you
+            resolved it, then the status of each verification command.
+
+      - name: Verify the merge is complete
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error::Conflicts are still unresolved:"
+            git diff --name-only --diff-filter=U
+            exit 1
+          fi
+          if git grep -n --no-color -E '^(<{7}|>{7}) ' -- . ; then
+            echo "::error::Conflict markers left in the tree (see above)."
+            exit 1
+          fi
+          test -f .git/MERGE_HEAD || {
+            echo "::error::MERGE_HEAD is gone - the merge was aborted or committed early."
+            exit 1
+          }
+
+      - name: Create the merge commit
+        if: steps.check.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add -A
+          git commit --no-verify -m "Merge base ${TAG}"
+          # Two parents expected: fork main, then the base tag.
+          git log --format='%h parents=%p %s' -1
+
+      - name: Run checks
+        id: checks
+        if: steps.check.outputs.skip == 'false'
+        continue-on-error: true
+        env:
+          BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          status=0
+          npm ci --ignore-scripts || status=1
+          npx prisma generate || status=1
+          npx basehub || status=1
+          npm run check-types || status=1
+          npm run lint || status=1
+          npm run check-formatting || status=1
+          if [ "$status" -eq 0 ]; then
+            echo "result=passing" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failing" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$status"
+
+      - name: Push branch and open pull request
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.tag.outputs.branch }}
+          CONFLICTS: ${{ steps.merge.outputs.conflicts }}
+          CHECKS: ${{ steps.checks.outputs.result }}
+          FILES: ${{ steps.merge.outputs.files }}
+        run: |
+          set -euo pipefail
+          git push origin "${BRANCH}"
+
+          if [ "${CONFLICTS}" = 'true' ]; then
+            CONFLICT_LINE="⚠️ **Conflicts were resolved by Claude Code** — review the merge commit carefully."
+            CONFLICT_DETAIL="$(printf '%s\n' "${FILES}" | sed "s/^/- \`/; s/\$/\`/")"
+          else
+            CONFLICT_LINE="✅ Merged cleanly, no conflicts."
+            CONFLICT_DETAIL="_none_"
+          fi
+
+          if [ "${CHECKS}" = 'passing' ]; then
+            CHECK_LINE="✅ \`check-types\`, \`lint\` and \`check-formatting\` pass."
+          else
+            CHECK_LINE="❌ Post-merge checks **failed** — see the \`Run checks\` step in the workflow run."
+          fi
+
+          # printf rather than a heredoc: a heredoc body must start at column 0,
+          # which would terminate this YAML block scalar.
+          {
+            printf '%s\n\n' "Merges [\`${TAG}\`](https://github.com/${BASE_REPO}/releases/tag/${TAG}) from \`${BASE_REPO}\` into this fork."
+            printf '%s\n' "${CONFLICT_LINE}"
+            printf '%s\n\n' "${CHECK_LINE}"
+            printf '%s\n\n' "### Conflicted files"
+            printf '%s\n\n' "${CONFLICT_DETAIL}"
+            cat .github/sync-base/pr-checklist.md
+            printf '\n%s\n' "---"
+            printf '%s\n' "Opened by \`sync-base-release.yml\` · [workflow run](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+          } > "${RUNNER_TEMP}/pr-body.md"
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Merge base ${TAG}" \
+            --body-file "${RUNNER_TEMP}/pr-body.md"


### PR DESCRIPTION
Adds `.github/workflows/sync-base-release.yml`: a daily job that watches `spliit-app/spliit` for new releases and opens a PR here containing a real merge commit for the new tag, with Claude Code resolving conflicts first.

### How it works

1. Reads upstream's latest release (`releases/latest`, so drafts and prereleases are skipped).
2. Skips if the tag is already an ancestor of `main`, or if `sync-base-<tag>` already exists on the remote — re-running is always safe.
3. Creates `sync-base-<tag>` and runs `git merge --no-ff --no-commit`.
4. **Only if there are conflicts**, runs `anthropics/claude-code-action@v1` to resolve them.
5. Independently verifies no unmerged paths and no conflict markers remain, then creates the `Merge base <tag>` commit — matching the shape of the manual `sync-base-1.21.0` branch (two parents: fork `main` and the upstream tag).
6. Runs `check-types` / `lint` / `check-formatting`, then opens the PR with the result and a review checklist.

### Guardrails on the Claude step

It is explicitly forbidden from `git commit`, `git push`, `git merge --abort`, `git reset`, and `gh pr`. The workflow does all of that afterwards, so a bad resolution shows up as a reviewable diff rather than something already pushed. The verification step fails loudly rather than committing a half-resolved tree.

`.github/sync-base/CONFLICT_RESOLUTION.md` gives it the fork-specific context it cannot infer from the diff:

- The `CustomAnalyticsEvent` extension point upstream deliberately left for forks — take their `BaseAnalyticsEvent`, keep our `CustomAnalyticsEvent`.
- `README.md` is the one documented "take ours wholesale" case: our README is a five-line stub, upstream's is the full project readme, and it will conflict on nearly every sync.
- **Group and expense IDs must never reach Plausible** (#22) — flagged as an invariant that must not regress.
- Never hand-merge `package-lock.json`; regenerate it. Always `--ignore-scripts`, since `postinstall` runs `prisma migrate deploy`.

### Verification done

- `actionlint` clean.
- PR-body generation rendered locally for both the clean and conflicted cases.
- Decision logic dry-run against the live repo: correctly resolves `1.22.0`, sees it is not merged, sees no existing branch.
- `git merge-tree` predicts the real `1.22.0` merge conflicts on exactly `README.md`, `package.json`, `package-lock.json` — all three covered by the resolution guide.

### Before it can run

Secrets and setup are in [`.github/sync-base/README.md`](.github/sync-base/README.md). Short version: add `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) and, recommended, `SYNC_PAT`.

`SYNC_PAT` matters for two concrete reasons: PRs opened with `GITHUB_TOKEN` do not trigger `ci.yml`, and `GITHUB_TOKEN` cannot push changes to `.github/workflows/` — `merge-tree` shows upstream `1.22.0` does touch `ci.yml`, so that case is live today. The workflow falls back to `GITHUB_TOKEN` without it.

### Notes

- Polling rather than a `repository_dispatch` from the base repo: keeps fork-specific automation out of the public upstream repo and needs no cross-repo PAT stored there. Costs up to a day of latency; the dispatch alternative is documented if you'd rather have it immediate.
- Model is `claude-opus-5`; these merges are low-volume but the resolutions are subtle. Swap to `claude-sonnet-5` in `claude_args` for cheaper runs.
- Base tags are fetched with `--no-tags` on purpose: pushing a tag into this repo would trigger `cd.yml` and publish a Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6myf7yEJjBtaimX5dAEaF
