### PR TITLE
Take the sync job's Node version from ci.yml instead of pinning it

### DIFF
--- a/.github/sync-base/CONFLICT_RESOLUTION.md
+++ b/.github/sync-base/CONFLICT_RESOLUTION.md
@@ -130,7 +130,19 @@ Always pass `--ignore-scripts` to npm in CI: this repo's `postinstall` runs
 
 A corrupted lockfile has broken `main` before (`fix: repair corrupted
 package-lock.json breaking CI on main`, #556), so verify `npm ci
---ignore-scripts` succeeds afterwards.
+--ignore-scripts` succeeds afterwards. That verification is not optional
+ceremony — it is the only step that catches a lockfile out of sync with
+`package.json`, and it is exactly what CI runs.
+
+**Regenerate on the same npm major that CI uses.** npm 10 prunes
+`optionalDependencies` for every platform except the one it is running on;
+npm 11 keeps them all and rejects a pruned lockfile with
+`EUSAGE ... can only install packages when your package.json and
+package-lock.json are in sync`, listing `@img/sharp-*` and `@parcel/watcher-*`
+as missing. A lockfile regenerated under the wrong major passes `npm ci`
+locally and fails it in CI. The sync workflow now takes its Node version from
+`.github/workflows/ci.yml` for exactly this reason; if you regenerate by hand,
+match that version too.
 
 ### `messages/*.json`
 

--- a/.github/workflows/sync-base-release.yml
+++ b/.github/workflows/sync-base-release.yml
@@ -149,27 +149,6 @@ jobs:
               ;;
           esac
 
-      - name: Set up Node.js
-        if: steps.gate.outputs.proceed == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: 'npm'
-
-      - name: Install dependencies
-        if: steps.gate.outputs.proceed == 'true'
-        env:
-          BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # --ignore-scripts skips postinstall, which runs `prisma migrate deploy`
-          # and needs a live database.
-          npm ci --ignore-scripts
-          npx prisma generate
-          npx basehub
-          # basehub-types.d.ts is tracked but generated; keep it out of the merge commit.
-          git checkout -- basehub-types.d.ts
-
       - name: Merge base tag
         id: merge
         if: steps.gate.outputs.proceed == 'true'
@@ -196,6 +175,54 @@ jobs:
             echo "::warning::Merge of ${TAG} has conflicts - handing off to Claude Code."
             git diff --name-only --diff-filter=U
           fi
+
+      # Node is set up *after* the merge, from the merged ci.yml, so this job
+      # always resolves and verifies on the same version the PR's CI will use --
+      # including when a base release bumps it. Getting this wrong is not a
+      # cosmetic mismatch: npm 10 and npm 11 disagree about which optional
+      # platform binaries belong in package-lock.json, so regenerating the
+      # lockfile under the wrong major produces a lockfile that passes
+      # `npm ci` here and fails it in CI.
+      - name: Determine the Node version CI uses
+        id: node
+        if: steps.gate.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          version="$(sed -nE "s/^[[:space:]]*node-version:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?.*/\1/p" \
+            .github/workflows/ci.yml | head -1)"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read node-version from .github/workflows/ci.yml."
+            echo "::error::Fix the parser here rather than letting this job guess."
+            exit 1
+          fi
+          echo "CI uses Node ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+          cache: 'npm'
+
+      # Only for the conflict path, and only best-effort: if package.json or the
+      # lockfile is among the conflicts these cannot succeed yet, and Claude
+      # reinstalls once it has resolved them. The authoritative install is the
+      # clean `npm ci` in "Run checks" after the merge is committed.
+      - name: Pre-install dependencies for the conflict resolver
+        if: steps.gate.outputs.proceed == 'true' && steps.merge.outputs.conflicts == 'true'
+        continue-on-error: true
+        env:
+          BASEHUB_TOKEN: ${{ secrets.BASEHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # --ignore-scripts skips postinstall, which runs `prisma migrate deploy`
+          # and needs a live database.
+          npm ci --ignore-scripts || true
+          npx prisma generate || true
+          npx basehub || true
+          # basehub-types.d.ts is tracked but generated; keep it out of the merge.
+          git checkout -- basehub-types.d.ts || true
 
       - name: Resolve conflicts with Claude Code
         if: steps.gate.outputs.proceed == 'true' && steps.merge.outputs.conflicts == 'true'
@@ -227,12 +254,17 @@ jobs:
             2. `git add` each file as you finish it. Leave no conflict markers behind.
             3. If package.json or package-lock.json conflicted, do not hand-merge the
                lockfile: resolve package.json, then run `npm install --package-lock-only`
-               to regenerate package-lock.json, then `npm install --ignore-scripts` so
-               node_modules matches. Always pass --ignore-scripts to npm: this repo's
-               postinstall runs `prisma migrate deploy`, which needs a live database.
+               to regenerate package-lock.json. Then prove it is right by running
+               `npm ci --ignore-scripts`, which is exactly what CI runs and the only
+               thing that catches a lockfile that is out of sync with package.json.
+               Always pass --ignore-scripts to npm: this repo's postinstall runs
+               `prisma migrate deploy`, which needs a live database.
             4. Verify: `npm run check-types`, `npm run lint`, and `npm run check-formatting`
                (use `npm run prettier` to fix formatting). Fix what you reasonably can.
                If a failure needs a product decision, leave it and say so in your summary.
+               Dependencies may be missing or stale when you start — if a command fails
+               because node_modules is wrong, run `npm ci --ignore-scripts` followed by
+               `npx prisma generate` and `npx basehub`, then retry.
             5. `git checkout -- basehub-types.d.ts` if you accidentally regenerate it and
                it was not part of this merge.
 


### PR DESCRIPTION
Fixes the cause of the red CI on #28.

### What happened

The sync workflow pinned `node-version: 18`. This repository's CI has been on **Node 24** all along — I copied the 18 out of the `ci.yml` in a stale working tree when I first wrote the workflow, and never re-derived it.

So the sync job resolved conflicts and verified the merge on **Node 18 / npm 10**, while the PR's CI runs **Node 24 / npm 11**. Claude regenerated `package-lock.json` under npm 10, and npm 10 prunes `optionalDependencies` for every platform except the one it is running on:

| lockfile | `@img/sharp-*` + `@parcel/watcher-*` entries |
| --- | --- |
| base `1.22.0` | 38 |
| fork `main` before the merge | 38 |
| `sync-base-1.22.0` as generated | **4** — exactly the linux-x64 ones |

npm 11 expects the full set and rejects the pruned lockfile:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json are in sync.
npm error Missing: @img/sharp-darwin-arm64@0.35.3 from lock file
```

The nasty part is the false green: the job's own `npm ci --ignore-scripts` **passed** under npm 10, so the PR body said `✅ check-types, lint and check-formatting pass` while its CI was failing. A verification step that runs in a different environment than CI is not a verification step.

### The fix

Read `node-version` out of `.github/workflows/ci.yml` **after the merge** and hand it to `setup-node`. The sync now always runs on the version the PR's CI will use, including when a base release bumps it. If the value cannot be parsed the job fails loudly rather than guessing — guessing is what caused this.

Consequences of setting up Node after the merge:

- Dependencies can no longer be installed before it, so the pre-install is now **conflict-path-only and best-effort** — a conflicted `package.json` or lockfile makes `npm ci` impossible until Claude has resolved them. Claude is told deps may be missing and how to recover.
- Claude is now told to prove a regenerated lockfile with `npm ci --ignore-scripts`, the exact check CI runs.
- The authoritative install is still the clean `npm ci` in `Run checks`, which now runs on the right Node.

`.github/sync-base/CONFLICT_RESOLUTION.md` records the npm-major trap for anyone resolving one of these merges by hand.

### Verification

Parser exercised against real inputs — the merged `ci.yml`, fork `main`, base `1.22.0`, plus quoted, `20.x`, trailing-comment, and absent forms: 9/9 as expected, and the absent case fails the job instead of defaulting. `actionlint` clean.

#28's lockfile is repaired separately (pushed straight to that branch) so it is not blocked on this merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6myf7yEJjBtaimX5dAEaF
