### PR TITLE
Add Open Collective news item, remove IndieHackers footer link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -178,16 +178,6 @@ function Content({ children }: { children: React.ReactNode }) {
                     </Link>
                   </Button>
                 </li>
-                <li>
-                  <Button variant="link" size="sm" asChild>
-                    <Link
-                      target="_blank"
-                      href="https://www.indiehackers.com/product/spliit"
-                    >
-                      IndieHackers
-                    </Link>
-                  </Button>
-                </li>
               </ul>
             </span>
             <span>

--- a/src/components/news-button.tsx
+++ b/src/components/news-button.tsx
@@ -21,11 +21,13 @@ import {
 } from '@/components/ui/popover'
 import { useAnalytics } from '@/lib/analytics/context'
 import { useLocalStorageState, useMediaQuery } from '@/lib/hooks'
+import { openCollective } from '@/lib/opencollective'
 import { GitHubLogoIcon } from '@radix-ui/react-icons'
 import {
   BarChart,
   ExternalLink,
   Globe,
+  HeartHandshake,
   Linkedin,
   LucideIcon,
   Newspaper,
@@ -49,6 +51,53 @@ type News = {
 }
 
 const news: News[] = [
+  {
+    id: 'open-collective',
+    title: <>Spliit’s funding is now on Open Collective</>,
+    summary: (
+      <>
+        Donations now go through Open Collective, where anyone can see what
+        comes in and what goes out.
+      </>
+    ),
+    icon: HeartHandshake,
+    content: (
+      <>
+        <p>
+          Spliit used to be funded through GitHub Sponsors and a Stripe donation
+          link, which meant the money went through my personal account. It now
+          goes through Open Collective instead.
+        </p>
+        <p>
+          Everything is public there: every donation, every expense, and the
+          current balance. The money covers the hosting costs — around $150 a
+          month — and is never used to pay me or the contributors.
+        </p>
+        <p className="flex items-center gap-2">
+          <Button asChild>
+            <a
+              target="_blank"
+              href="/blog/spliit-funding-is-now-on-open-collective"
+              className="no-underline"
+            >
+              <ExternalLink className="mr-2 w-4" />
+              Read the blog post
+            </a>
+          </Button>
+          <Button variant="secondary" asChild>
+            <a
+              target="_blank"
+              href={openCollective.url}
+              className="no-underline"
+            >
+              <HeartHandshake className="mr-2 w-4" />
+              Open Collective
+            </a>
+          </Button>
+        </p>
+      </>
+    ),
+  },
   {
     id: 'mobile-app',
     title: <>The iOS app is here!</>,


### PR DESCRIPTION
Two small changes.

### Announce the move to Open Collective

The blog post [Spliit's Funding Is Now on Open Collective](https://spliit.app/blog/spliit-funding-is-now-on-open-collective) is live, so this adds a matching entry at the top of the news widget.

- New `open-collective` news item, first in the list (so the pink "unseen" ping fires for everyone).
- Two actions: **Read the blog post** → the live post, and **Open Collective** → the collective.
- Reuses the `openCollective` helper from #26 instead of hardcoding the URL again.
- Icon: `HeartHandshake` from lucide.
- Copy states hosting costs "around $150 a month", matching the published post.

### Remove the IndieHackers footer link

Drops the `IndieHackers` entry from the footer's social list in `src/app/layout.tsx`. It was the last `<li>`; LinkedIn, GitHub and Reddit are untouched. No other references to indiehackers remain in the codebase.

---

Checks run on both: `tsc --noEmit` clean, `eslint` clean, `prettier -c` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hb3gi8r7bNviufb4yUDKH