### PR TITLE
Turn the open source section into an invitation to contribute

### DIFF
--- a/src/app/contribute-routes.tsx
+++ b/src/app/contribute-routes.tsx
@@ -40,9 +40,9 @@ const contributeRoutes: ContributeRoute[] = [
     Icon: Code2,
     name: 'Write code',
     description:
-      'Spliit is a Next.js application, written in TypeScript and styled with Tailwind. Some issues are marked as a good place to start.',
-    action: 'Find a first issue',
-    href: github.goodFirstIssues,
+      'Spliit is a Next.js application, written in TypeScript and styled with Tailwind. Pick up an open issue, or bring an idea of your own.',
+    action: 'Browse open issues',
+    href: github.issues,
   },
   {
     id: 'translate',

--- a/src/app/contribute-routes.tsx
+++ b/src/app/contribute-routes.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { locales } from '@/i18n/request'
+import { useAnalytics } from '@/lib/analytics/context'
+import { github } from '@/lib/github'
+import { openCollective } from '@/lib/opencollective'
+import {
+  ArrowRight,
+  Code2,
+  HeartHandshake,
+  Languages,
+  LucideIcon,
+  Megaphone,
+} from 'lucide-react'
+import { ReactNode } from 'react'
+
+/**
+ * Weblate's “engage” page rather than the project page: it is the one built to
+ * onboard a translator who has never used Weblate before.
+ */
+const WEBLATE_URL = 'https://hosted.weblate.org/engage/spliit/'
+
+type ContributeRoute = {
+  id: 'code' | 'translate' | 'fund' | 'share'
+  Icon: LucideIcon
+  name: string
+  description: ReactNode
+  action: string
+  href: string
+}
+
+/**
+ * “Contributing” means four unrelated things depending on who is reading, and
+ * only one of them involves writing code. Each gets its own entry point rather
+ * than a single link to the repository.
+ */
+const contributeRoutes: ContributeRoute[] = [
+  {
+    id: 'code',
+    Icon: Code2,
+    name: 'Write code',
+    description:
+      'Spliit is a Next.js application, written in TypeScript and styled with Tailwind. Some issues are marked as a good place to start.',
+    action: 'Find a first issue',
+    href: github.goodFirstIssues,
+  },
+  {
+    id: 'translate',
+    Icon: Languages,
+    name: 'Translate it',
+    description: `Spliit is available in ${locales.length} languages, added and kept up to date by the people who speak them. Fixing a wording takes a minute in your browser, with nothing to install.`,
+    action: 'Translate on Weblate',
+    href: WEBLATE_URL,
+  },
+  {
+    id: 'fund',
+    Icon: HeartHandshake,
+    name: 'Fund the servers',
+    description:
+      'Hosting, the database and receipt scanning are paid for by donations, on a public ledger where anyone can see what comes in and what it pays for.',
+    action: 'Contribute on Open Collective',
+    href: openCollective.contribute,
+  },
+  {
+    id: 'share',
+    Icon: Megaphone,
+    name: 'Spread the word',
+    description:
+      'Most people hear about Spliit from someone they know. Tell a friend the next time you split a bill, or star the repository.',
+    action: 'Star it on GitHub',
+    href: github.url,
+  },
+]
+
+export function ContributeRoutes() {
+  const sendEvent = useAnalytics()
+
+  return (
+    <ul className="mt-8 w-full grid sm:grid-cols-2 gap-2 sm:gap-4 text-left">
+      {contributeRoutes.map(({ id, Icon, name, description, action, href }) => (
+        <li key={id} className="flex">
+          {/* The whole card is the link: the action label alone would be a
+              needlessly small target on a phone. */}
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() =>
+              sendEvent({ event: 'contribute: click', props: { route: id } })
+            }
+            className="group bg-card border rounded-md p-4 flex flex-col gap-2 w-full hover:border-primary hover:shadow-sm transition-all"
+          >
+            <Icon className="w-8 h-8" aria-hidden />
+            <strong>{name}</strong>
+            <span
+              className="text-sm text-muted-foreground"
+              style={{ textWrap: 'balance' } as any}
+            >
+              {description}
+            </span>
+            <span className="mt-auto pt-2 text-sm font-medium text-primary flex items-center gap-1">
+              {action}
+              <ArrowRight
+                className="w-4 h-4 group-hover:translate-x-0.5 transition-transform"
+                aria-hidden
+              />
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/app/contributors.tsx
+++ b/src/app/contributors.tsx
@@ -1,5 +1,16 @@
+import { getContributors, github } from '@/lib/github'
+import { Plus } from 'lucide-react'
 import Image from 'next/image'
-import { Octokit } from 'octokit'
+import { ReactNode } from 'react'
+
+const AVATAR_SIZE = 60
+
+/**
+ * Enough faces to show that this is a crowd, few enough that the invitation
+ * below them stays on screen. The rest are one click away, and the exact count
+ * is spelled out by `RepoStatsLine`.
+ */
+const MAX_AVATARS = 30
 
 export async function Contributors() {
   const contributors = await getContributors()
@@ -7,38 +18,72 @@ export async function Contributors() {
     return <div>Error loading contributors</div>
   }
 
+  const shown = contributors.slice(0, MAX_AVATARS)
+  const remaining = contributors.length - shown.length
+
   return (
     <ul style={{ textWrap: 'balance' } as any}>
-      {contributors.map((contributor) =>
-        contributor.avatar_url !== undefined &&
-        contributor.login !== undefined ? (
-          <li key={contributor.login} className="inline-block px-1">
-            <a href={contributor.html_url} target="_blank" rel="nofollow">
-              <Image
-                src={contributor.avatar_url}
-                width={60}
-                height={60}
-                alt={contributor.login ?? ''}
-                className="rounded-full border hover:scale-110 transition-transform"
-              />
-            </a>
-          </li>
-        ) : null,
+      {shown.map((contributor) => (
+        <li key={contributor.login} className="inline-block px-1">
+          <a href={contributor.profileUrl} target="_blank" rel="nofollow">
+            <Image
+              src={contributor.avatarUrl}
+              width={AVATAR_SIZE}
+              height={AVATAR_SIZE}
+              alt={contributor.login}
+              className="rounded-full border hover:scale-110 transition-transform"
+            />
+          </a>
+        </li>
+      ))}
+      {remaining > 0 && (
+        <li className="inline-block px-1 align-top">
+          <CircleTile
+            href={github.contributors}
+            title={`${remaining} more contributors`}
+            className="border bg-card text-muted-foreground hover:text-primary"
+          >
+            <span className="text-sm font-medium">+{remaining}</span>
+          </CircleTile>
+        </li>
       )}
+      <li className="inline-block px-1 align-top">
+        {/* Closes the row with an empty slot: a list of people who already
+            contributed reads as a credit roll, this makes it an invitation. */}
+        <CircleTile
+          href={github.goodFirstIssues}
+          title="Your avatar could be here"
+          className="border-2 border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary"
+        >
+          <Plus className="w-4 h-4" aria-hidden />
+          <span className="text-[10px] font-medium leading-none">you?</span>
+        </CircleTile>
+      </li>
     </ul>
   )
 }
 
-const getContributors = async () => {
-  try {
-    const octokit = new Octokit()
-    const { data: contributors } = await octokit.rest.repos.listContributors({
-      owner: 'spliit-app',
-      repo: 'spliit',
-    })
-    return contributors
-  } catch (error) {
-    console.error(error)
-    return null
-  }
+function CircleTile({
+  href,
+  title,
+  className,
+  children,
+}: {
+  href: string
+  title: string
+  className: string
+  children: ReactNode
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title={title}
+      className={`flex flex-col items-center justify-center rounded-full hover:scale-110 transition-all ${className}`}
+      style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+    >
+      {children}
+    </a>
+  )
 }

--- a/src/app/contributors.tsx
+++ b/src/app/contributors.tsx
@@ -51,7 +51,7 @@ export async function Contributors() {
         {/* Closes the row with an empty slot: a list of people who already
             contributed reads as a credit roll, this makes it an invitation. */}
         <CircleTile
-          href={github.goodFirstIssues}
+          href={github.issues}
           title="Your avatar could be here"
           className="border-2 border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary"
         >

--- a/src/app/github-star-pill.tsx
+++ b/src/app/github-star-pill.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useAnalytics } from '@/lib/analytics/context'
+import { github } from '@/lib/github'
+import { Star } from 'lucide-react'
+
+/**
+ * The star count is passed in rather than fetched here: the request belongs on
+ * the server, and only the click handler needs to run in the browser.
+ */
+export function GitHubStarPillLink({ stars }: { stars: number }) {
+  const sendEvent = useAnalytics()
+
+  return (
+    <a
+      href={github.url}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() =>
+        sendEvent({ event: 'contribute: click', props: { route: 'share' } })
+      }
+      className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-1 text-sm text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+    >
+      <Star className="w-3.5 h-3.5 fill-current" aria-hidden />
+      {/* One flex item, so that the gap above separates the icon from the label
+          without also spacing out the words. */}
+      <span>
+        <span className="font-medium">{stars.toLocaleString('en-US')}</span>{' '}
+        stars on GitHub
+      </span>
+    </a>
+  )
+}

--- a/src/app/github-stats.tsx
+++ b/src/app/github-stats.tsx
@@ -1,0 +1,35 @@
+import { GitHubStarPillLink } from '@/app/github-star-pill'
+import { getContributors, getRepoStats } from '@/lib/github'
+
+/**
+ * Social proof in the hero, where the “Open Source” claim is made. Renders
+ * nothing when GitHub cannot be reached, rather than an empty pill.
+ */
+export async function GitHubStarPill() {
+  const stats = await getRepoStats()
+  if (!stats) return null
+  return <GitHubStarPillLink stars={stats.stars} />
+}
+
+/**
+ * The same numbers, restated under the contributor wall as evidence that the
+ * invitation next to it is a real one. Both calls are memoized per render, so
+ * this shares its requests with the pill and with `Contributors`.
+ */
+export async function RepoStatsLine() {
+  const [stats, contributors] = await Promise.all([
+    getRepoStats(),
+    getContributors(),
+  ])
+  if (!stats) return null
+
+  const parts = [
+    contributors && `${contributors.length} contributors`,
+    `${stats.stars.toLocaleString('en-US')} stars`,
+    `${stats.forks.toLocaleString('en-US')} forks`,
+  ].filter(Boolean)
+
+  return (
+    <p className="mt-4 text-sm text-muted-foreground">{parts.join(' · ')}</p>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
+import { ContributeRoutes } from '@/app/contribute-routes'
 import { Contributors } from '@/app/contributors'
+import { GitHubStarPill, RepoStatsLine } from '@/app/github-stats'
 import { StatsDisplay } from '@/app/stats-display'
 import { FeedbackModal } from '@/components/feedback-button/feedback-button'
 import {
@@ -10,6 +12,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { TrackPage } from '@/lib/analytics/track-page'
+import { github } from '@/lib/github'
 import {
   BarChartHorizontalBig,
   Calendar,
@@ -43,8 +46,16 @@ export default function HomePage() {
             })}
           </h1>
           <p className="max-w-[42rem] leading-normal text-muted-foreground sm:text-xl sm:leading-8">
-            No ads. No account. <br className="sm:hidden" /> Open Source.
-            Forever Free.
+            No ads. No account. <br className="sm:hidden" />{' '}
+            {/* The most prominent mention of open source on the site, and until
+                now the only one that led nowhere. */}
+            <a
+              href="#contribute"
+              className="underline decoration-dotted underline-offset-4 hover:text-foreground transition-colors"
+            >
+              Open Source
+            </a>
+            . Forever Free.
           </p>
           <div className="flex gap-2">
             <Button asChild size="lg">
@@ -54,6 +65,9 @@ export default function HomePage() {
               <Link href="/blog">Read our blog</Link>
             </Button>
           </div>
+          <Suspense fallback={null}>
+            <GitHubStarPill />
+          </Suspense>
           <p className="mt-12 max-w-[42rem] leading-normal text-muted-foreground text-xl sm:text-2xl sm:leading-8">
             <StatsDisplay />
           </p>
@@ -129,7 +143,8 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="py-16 md:py-24 lg:py-32">
+      {/* Linked to from the hero, and the anchor sits below the fixed header. */}
+      <section id="contribute" className="scroll-mt-20 py-16 md:py-24 lg:py-32">
         <div className="container flex max-w-screen-md flex-col items-center text-center">
           <h2 className="font-bold text-3xl leading-[1.1] sm:text-3xl md:text-6xl">
             Proudly Open Source
@@ -138,30 +153,23 @@ export default function HomePage() {
             className="mt-2 leading-normal text-muted-foreground sm:text-lg sm:leading-7"
             style={{ textWrap: 'balance' } as any}
           >
-            Spliit is open source and lives thanks to amazing{' '}
-            <a
-              className="underline"
-              target="_blank"
-              href="https://github.com/spliit-app/spliit/graphs/contributors"
-            >
-              contributors
-            </a>
-            !
+            Spliit is built in the open by the people who use it — and there is
+            a way in for you too, whether or not you write code.
           </p>
           <div className="mt-6">
             <Suspense fallback={<div>Loading...</div>}>
               <Contributors />
             </Suspense>
+            <Suspense fallback={null}>
+              <RepoStatsLine />
+            </Suspense>
           </div>
-          <div className="mt-4 md:mt-6">
+          <ContributeRoutes />
+          <div className="mt-6">
             <Button asChild variant="secondary" size="lg">
-              <a
-                target="_blank"
-                rel="noreferrer"
-                href="https://github.com/spliit-app/spliit"
-              >
+              <a target="_blank" rel="noreferrer" href={github.url}>
                 <Github className="w-4 h-4 mr-2" />
-                GitHub
+                Browse the code
               </a>
             </Button>
           </div>
@@ -255,36 +263,13 @@ export default function HomePage() {
                 id="contribute"
                 question={<>I use Spliit and like it. How can I contribute?</>}
               >
-                <p>You can contribute to Spliit by several ways.</p>
-                <ul>
-                  <li>
-                    You can share it with your community on social media to let
-                    them know about us,
-                  </li>
-                  <li>
-                    You can{' '}
-                    <FeedbackModal defaultTab="support">
-                      <Button
-                        variant="link"
-                        className="text-base text-pink-600 -mx-4 -my-4"
-                      >
-                        support our hosting costs
-                      </Button>
-                    </FeedbackModal>{' '}
-                    by contributing on Open Collective,
-                  </li>
-                  <li>
-                    If you’re a developer, you can implement new features or
-                    improve the user experience! Go to{' '}
-                    <a
-                      target="_blank"
-                      href="https://github.com/spliit-app/spliit"
-                    >
-                      our GitHub repository
-                    </a>{' '}
-                    to know more about the project.
-                  </li>
-                </ul>
+                <p>
+                  In several ways, and most of them need no code at all: you can
+                  translate the application into your language, help pay for the
+                  servers, tell people about Spliit, or implement a feature
+                  yourself. See <a href="#contribute">Proudly Open Source</a>{' '}
+                  above for where each of those starts.
+                </p>
               </Answer>
             </Accordion>
           </div>

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -28,5 +28,11 @@ type CustomAnalyticsEvent =
   // The news ID identifies a piece of content rather than a user, and there are
   // only ever a handful of them, so it stays low-cardinality.
   | { event: 'news: click news'; props: { news: string } }
+  // Which of the contribution paths offered on the home page was taken. A fixed
+  // handful of values, none of them tied to a visitor.
+  | {
+      event: 'contribute: click'
+      props: { route: 'code' | 'translate' | 'fund' | 'share' }
+    }
 
 export type AnalyticsEvent = BaseAnalyticsEvent | CustomAnalyticsEvent

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -12,12 +12,6 @@ const REPO_API_URL = 'https://api.github.com/repos/spliit-app/spliit'
 export const github = {
   url: REPO_URL,
   issues: `${REPO_URL}/issues`,
-  // Deep-linked to the label rather than to the issue list: someone looking for
-  // a first contribution lands on hundreds of unsorted issues otherwise, and
-  // leaves.
-  goodFirstIssues: `${REPO_URL}/issues?q=${encodeURIComponent(
-    'is:issue is:open label:"good first issue"',
-  )}`,
   contributors: `${REPO_URL}/graphs/contributors`,
 } as const
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,99 @@
+import { cache } from 'react'
+
+const REPO_URL = 'https://github.com/spliit-app/spliit'
+const REPO_API_URL = 'https://api.github.com/repos/spliit-app/spliit'
+
+/**
+ * Spliit's source repository, and the pages people are sent to from the home
+ * page. Hardcoded rather than configurable, for the same reason as
+ * `openCollective`: these point at the project itself, not at whoever runs a
+ * given instance.
+ */
+export const github = {
+  url: REPO_URL,
+  issues: `${REPO_URL}/issues`,
+  // Deep-linked to the label rather than to the issue list: someone looking for
+  // a first contribution lands on hundreds of unsorted issues otherwise, and
+  // leaves.
+  goodFirstIssues: `${REPO_URL}/issues?q=${encodeURIComponent(
+    'is:issue is:open label:"good first issue"',
+  )}`,
+  contributors: `${REPO_URL}/graphs/contributors`,
+} as const
+
+/**
+ * The unauthenticated GitHub API allows 60 calls an hour per IP address, and
+ * the home page is rendered per request (the root layout reads the locale from
+ * cookies, so nothing on the page is static). Both calls below are therefore
+ * revalidated hourly instead of made once per visitor.
+ */
+const REVALIDATE_SECONDS = 3600
+
+/**
+ * Returns `null` rather than throwing on any failure — a rate-limited API or a
+ * GitHub outage must not take the home page down with it. Every caller renders
+ * without the data instead.
+ */
+async function fetchFromGitHub<T>(path: string): Promise<T | null> {
+  try {
+    const response = await fetch(`${REPO_API_URL}${path}`, {
+      headers: { Accept: 'application/vnd.github+json' },
+      next: { revalidate: REVALIDATE_SECONDS },
+    })
+    if (!response.ok) {
+      console.error(
+        `GitHub API responded ${response.status} for ${REPO_API_URL}${path}`,
+      )
+      return null
+    }
+    return (await response.json()) as T
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
+export type RepoStats = {
+  stars: number
+  forks: number
+}
+
+/**
+ * Wrapped in React's `cache` so that the hero and the contribute section, which
+ * both display these numbers, share a single request per render.
+ */
+export const getRepoStats = cache(async (): Promise<RepoStats | null> => {
+  const repo = await fetchFromGitHub<{
+    stargazers_count: number
+    forks_count: number
+  }>('')
+  if (!repo) return null
+  return { stars: repo.stargazers_count, forks: repo.forks_count }
+})
+
+export type Contributor = {
+  login: string
+  avatarUrl: string
+  profileUrl: string
+}
+
+export const getContributors = cache(
+  async (): Promise<Contributor[] | null> => {
+    const contributors = await fetchFromGitHub<
+      { login?: string; avatar_url?: string; html_url?: string }[]
+    >('/contributors?per_page=100')
+    if (!contributors) return null
+
+    return contributors.flatMap((contributor) =>
+      contributor.login && contributor.avatar_url && contributor.html_url
+        ? [
+            {
+              login: contributor.login,
+              avatarUrl: contributor.avatar_url,
+              profileUrl: contributor.html_url,
+            },
+          ]
+        : [],
+    )
+  },
+)


### PR DESCRIPTION
The home page mentioned contributing in two places, and neither asked for anything:

- **“Proudly Open Source”** was a credit roll — avatars of people who already contributed, plus a `secondary` button labelled “GitHub”, which reads as *view the source*, not *join us*.
- **An FAQ answer** with the best copy on the page, collapsed by default, last item of the last section.

Meanwhile the hero’s “Open Source” — the most-read mention of it on the site — was plain text, and nothing anywhere mentioned Weblate or Open Collective.

## What changed

**The section now asks.** Four entry points, because only one of them involves writing code:

| Route | Goes to |
| --- | --- |
| Write code | the open issues |
| Translate it | Weblate, with the language count read from `locales` |
| Fund the servers | Open Collective |
| Spread the word | the repository, to star it |

**The avatar wall becomes an invitation.** It keeps its 30 faces, then a `+59` tile linking to the contributors graph, then a dashed “+ you?” slot pointing at the issue list. Live counts underneath: contributors · stars · forks.

**The hero links somewhere.** “Open Source” now anchors to the section (`scroll-mt-20`, so the heading clears the fixed header), with a star-count pill under the buttons.

**The FAQ answer** no longer repeats the section — it points at it.

## Along the way

- Both GitHub calls moved to `src/lib/github.ts` and are **revalidated hourly**. They were being made per visitor against an API that allows 60 calls an hour per IP, and nothing on this page is static (the root layout reads the locale from cookies). Failures return `null` and the page renders without the numbers.
- The wall is capped at 30 deliberately: `per_page=100` returns all 89 contributors, which pushed the invitation clean off the screen.
- New `contribute: click` event with a `route` property, so the four paths can be compared. Note that outbound-link tracking was removed in the analytics refactor, so without this the change would not be measurable.

## Verified

`check-types`, `eslint` (0 errors), `prettier`, `jest` (101 passing). Rendered against a local dev server: live data (89 contributors · 2,850 stars · 472 forks), light and dark, desktop and 390px. Clicking each route with `ANALYTICS_PROVIDER=console` fires `contribute: click` with the anonymized `/` URL.

## Worth deciding before merge

The “Write code” card sends people to all 243 open issues. It first linked to the `good first issue` label, but that list is empty, so the filter came back out. Labelling a handful of issues and restoring the filter would give newcomers somewhere to land; as it stands, the card is honest but the landing is steep.

Also open: whether this belongs upstream in `spliit-app/spliit` instead of (or as well as) here, since the landing page is shared and this will conflict on every base sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtSugpo9JEkCYsZAVoFpMm