### PR TITLE
Publish a privacy policy the App Store can link to, and serve the Universal Links file

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -15,6 +15,74 @@
     "builtBy": "Built by <author>Sebastien Castiel</author> and <source>contributors</source>",
     "onOurBlog": "On our blog"
   },
+  "PrivacyPolicy": {
+    "title": "Privacy Policy",
+    "lastUpdated": "Last updated on August 24, 2026",
+    "metaDescription": "What Spliit stores, what stays on your device, and who else sees it.",
+    "intro": "Spliit is a free and open source application for sharing expenses with friends and family, used from a web browser or from the Spliit app for iOS. This policy describes what the application keeps, what leaves your device, and who else sees it. It applies to the instance serving this page: on <link>spliit.app</link> that instance is operated by Sebastien Castiel, and any other one is covered by “Self-hosting” below.",
+    "noAccount": {
+      "title": "No account, no identity",
+      "body": "Spliit has no accounts. You are never asked for a name, an email address or a password, there is nothing to sign in to, and nothing you do is attached to an identity. We cannot tell who you are, and we do not try to."
+    },
+    "whatIsStored": {
+      "title": "What is stored on the server",
+      "body": "The groups you create are stored on the server: the group’s name, description and currency, the names of its participants, and for every expense its title, amount, date, category, the participant who paid, how it is split, and any notes. This is what the application exists to keep, and it is kept for as long as the group exists.",
+      "documents": "If you attach a receipt or another document to an expense, the image is stored with the file storage this instance is configured to use, and its address is saved with the expense."
+    },
+    "groupLinks": {
+      "title": "Who can see a group",
+      "body": "A group is reachable through its link and through nothing else. There is no directory, no search across groups, and no way to list the groups on the server. Anyone who has the link, though, can read the group and change it — so treat a group link the way you would treat a key, and share it only with the people in the group."
+    },
+    "onYourDevice": {
+      "title": "What stays on your device",
+      "body": "The list of groups you have opened, which of them you have starred or archived, the language and theme you picked, the splitting options you used last, and, in the iOS app, the address of the server you chose. All of it stays in your browser or on your device. Your list of groups is never sent to the server: it has no idea which groups belong together in your list."
+    },
+    "analytics": {
+      "title": "Analytics",
+      "provider": "This instance measures how it is used with Plausible Analytics, which is cookieless, sets no identifier and collects no personal data. It receives the address of the page you are on and a short list of events — a group created, an expense created or deleted, a receipt scanned, and a few more of that kind.",
+      "noIds": "Group and expense identifiers are stripped before anything is sent: a page is reported as <code>/groups/[groupId]/expenses</code> rather than under its real address. That identifier is what gives access to a group, so it never reaches analytics, and no event carries anything you typed.",
+      "noTracking": "There is no advertising, no profiling, and no tracking of you across other websites or applications.",
+      "disabled": "This instance collects no usage statistics at all."
+    },
+    "ai": {
+      "title": "Scanning receipts and suggesting categories",
+      "receipt": "When you create an expense by scanning a receipt, the picture of the receipt is sent to OpenAI, which reads the total, the date and a title from it. This happens only when you use that feature, and only with the picture you chose.",
+      "category": "When the application suggests a category for an expense, the title you typed is sent to OpenAI to make that suggestion. Nothing else about the expense goes with it.",
+      "training": "OpenAI processes those requests on our behalf. Under the terms of their API, what is sent is not used to train their models."
+    },
+    "logs": {
+      "title": "Technical logs",
+      "body": "Like any website, the servers running Spliit keep short-lived technical logs of the requests they receive: the address requested, the time, the browser or app used, and the network address it came from. They serve to keep the service running and to deal with abuse, and nothing else."
+    },
+    "cookies": {
+      "title": "Cookies",
+      "body": "One cookie, which remembers the language you chose. There are no advertising cookies and no tracking cookies."
+    },
+    "deleting": {
+      "title": "Deleting your data",
+      "body": "An expense can be deleted from within its group at any time, and a group can be removed from the list on your device. Deleting a group from the server is not something the application can do yet: write to <contact>hello@spliit.app</contact> with the group’s link and it will be deleted for you."
+    },
+    "children": {
+      "title": "Children",
+      "body": "Spliit is not directed at children, and asks for no personal information from anyone of any age. If you believe a child has entered personal information into a group on this instance, write to <contact>hello@spliit.app</contact> and it will be removed."
+    },
+    "security": {
+      "title": "Security",
+      "body": "Traffic to and from Spliit is encrypted. There are no accounts, so there are no passwords to steal and no credentials to lose. The privacy of a group rests on its link staying among the people who should have it."
+    },
+    "selfHosting": {
+      "title": "Self-hosting",
+      "body": "Spliit is open source, and anyone can run their own instance. If you run one, or point the iOS app at one in its settings, your groups are stored on that server and nothing about them reaches spliit.app. This policy then describes that instance, and whoever runs it answers for it."
+    },
+    "changes": {
+      "title": "Changes to this policy",
+      "body": "This page is updated when what the application does changes. The date at the top says when it was last touched, and its whole history is public in the <repository>source repository</repository>."
+    },
+    "contact": {
+      "title": "Contact",
+      "body": "For any question about privacy, or to have data deleted, write to <contact>hello@spliit.app</contact>."
+    }
+  },
   "Support": {
     "buttonLabel": "Support us",
     "title": "Support us",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -14,6 +14,74 @@
     "madeIn": "Made in Montréal, Québec 🇨🇦",
     "builtBy": "Développé par <author>Sebastien Castiel</author> et <source>contributeurs</source>"
   },
+  "PrivacyPolicy": {
+    "title": "Politique de confidentialité",
+    "lastUpdated": "Dernière mise à jour le 24 août 2026",
+    "metaDescription": "Ce que Spliit conserve, ce qui reste sur votre appareil, et qui d’autre y a accès.",
+    "intro": "Spliit est une application libre et gratuite pour partager des dépenses entre amis ou en famille, utilisable depuis un navigateur web ou depuis l’application Spliit pour iOS. Cette politique décrit ce que l’application conserve, ce qui quitte votre appareil, et qui d’autre y a accès. Elle s’applique à l’instance qui affiche cette page : sur <link>spliit.app</link>, cette instance est exploitée par Sebastien Castiel ; toute autre relève de la section « Héberger sa propre instance » plus bas.",
+    "noAccount": {
+      "title": "Aucun compte, aucune identité",
+      "body": "Spliit n’a pas de comptes. On ne vous demande jamais de nom, d’adresse e-mail ni de mot de passe, il n’y a rien à quoi se connecter, et rien de ce que vous faites n’est rattaché à une identité. Nous ne savons pas qui vous êtes, et nous ne cherchons pas à le savoir."
+    },
+    "whatIsStored": {
+      "title": "Ce qui est enregistré sur le serveur",
+      "body": "Les groupes que vous créez sont enregistrés sur le serveur : le nom du groupe, sa description et sa devise, les noms de ses participants, et pour chaque dépense son titre, son montant, sa date, sa catégorie, le participant qui a payé, la façon dont elle est partagée et les notes qui l’accompagnent. C’est ce que l’application existe pour conserver, et elles le restent aussi longtemps que le groupe existe.",
+      "documents": "Si vous joignez un reçu ou un autre document à une dépense, l’image est enregistrée sur le stockage de fichiers configuré pour cette instance, et son adresse est conservée avec la dépense."
+    },
+    "groupLinks": {
+      "title": "Qui peut voir un groupe",
+      "body": "Un groupe est accessible par son lien, et par rien d’autre : il n’existe ni annuaire, ni recherche entre les groupes, ni moyen de lister les groupes du serveur. En revanche, quiconque possède le lien peut lire le groupe et le modifier — traitez donc un lien de groupe comme une clé, et ne le partagez qu’avec les personnes du groupe."
+    },
+    "onYourDevice": {
+      "title": "Ce qui reste sur votre appareil",
+      "body": "La liste des groupes que vous avez ouverts, ceux que vous avez mis en favori ou archivés, la langue et le thème que vous avez choisis, les options de partage utilisées la dernière fois, et, dans l’application iOS, l’adresse du serveur que vous avez choisi. Tout cela reste dans votre navigateur ou sur votre appareil. Votre liste de groupes n’est jamais envoyée au serveur : celui-ci ignore quels groupes se trouvent ensemble dans votre liste."
+    },
+    "analytics": {
+      "title": "Mesure d’audience",
+      "provider": "Cette instance mesure son utilisation avec Plausible Analytics, qui n’utilise aucun cookie, ne pose aucun identifiant et ne recueille aucune donnée personnelle. Lui sont envoyés l’adresse de la page consultée et une courte liste d’événements — un groupe créé, une dépense créée ou supprimée, un reçu numérisé, et quelques autres du même ordre.",
+      "noIds": "Les identifiants de groupe et de dépense sont retirés avant tout envoi : une page est rapportée comme <code>/groups/[groupId]/expenses</code> plutôt que sous son adresse réelle. Cet identifiant est ce qui donne accès à un groupe ; il n’atteint donc jamais la mesure d’audience, et aucun événement ne contient ce que vous avez saisi.",
+      "noTracking": "Il n’y a ni publicité, ni profilage, ni suivi de votre activité sur d’autres sites ou applications.",
+      "disabled": "Cette instance ne recueille aucune statistique d’utilisation."
+    },
+    "ai": {
+      "title": "Numérisation des reçus et suggestion de catégories",
+      "receipt": "Lorsque vous créez une dépense en numérisant un reçu, la photo du reçu est envoyée à OpenAI, qui y lit le montant total, la date et un titre. Cela n’arrive que lorsque vous utilisez cette fonction, et uniquement avec la photo que vous avez choisie.",
+      "category": "Lorsque l’application suggère une catégorie pour une dépense, le titre que vous avez saisi est envoyé à OpenAI pour produire cette suggestion. Rien d’autre de la dépense ne l’accompagne.",
+      "training": "OpenAI traite ces requêtes pour notre compte. Selon les conditions de leur API, ce qui leur est envoyé ne sert pas à entraîner leurs modèles."
+    },
+    "logs": {
+      "title": "Journaux techniques",
+      "body": "Comme tout site web, les serveurs qui font fonctionner Spliit conservent de brefs journaux techniques des requêtes qu’ils reçoivent : l’adresse demandée, l’heure, le navigateur ou l’application utilisés, et l’adresse réseau d’où provient la requête. Ils servent à maintenir le service en état de marche et à faire face aux abus, et à rien d’autre."
+    },
+    "cookies": {
+      "title": "Cookies",
+      "body": "Un seul cookie, qui retient la langue que vous avez choisie. Il n’y a ni cookie publicitaire, ni cookie de suivi."
+    },
+    "deleting": {
+      "title": "Supprimer vos données",
+      "body": "Une dépense peut être supprimée depuis son groupe à tout moment, et un groupe peut être retiré de la liste sur votre appareil. Supprimer un groupe du serveur n’est pas encore possible depuis l’application : écrivez à <contact>hello@spliit.app</contact> avec le lien du groupe et il sera supprimé pour vous."
+    },
+    "children": {
+      "title": "Enfants",
+      "body": "Spliit ne s’adresse pas aux enfants, et ne demande aucune information personnelle à qui que ce soit, quel que soit son âge. Si vous pensez qu’un enfant a saisi des informations personnelles dans un groupe de cette instance, écrivez à <contact>hello@spliit.app</contact> et elles seront supprimées."
+    },
+    "security": {
+      "title": "Sécurité",
+      "body": "Les échanges avec Spliit sont chiffrés. Il n’y a pas de comptes, donc pas de mots de passe à dérober ni d’identifiants à perdre. La confidentialité d’un groupe tient à son lien, qui doit rester entre les mains des personnes concernées."
+    },
+    "selfHosting": {
+      "title": "Héberger sa propre instance",
+      "body": "Spliit est un logiciel libre, et chacun peut en héberger sa propre instance. Si vous le faites, ou si vous pointez l’application iOS vers votre serveur dans ses réglages, vos groupes sont enregistrés sur ce serveur et rien les concernant n’atteint spliit.app. Cette politique décrit alors cette instance, et c’est la personne qui l’exploite qui en répond."
+    },
+    "changes": {
+      "title": "Modifications de cette politique",
+      "body": "Cette page est mise à jour lorsque le comportement de l’application change. La date en haut indique la dernière modification, et tout son historique est public dans le <repository>dépôt du code source</repository>."
+    },
+    "contact": {
+      "title": "Nous contacter",
+      "body": "Pour toute question relative à la confidentialité, ou pour faire supprimer des données, écrivez à <contact>hello@spliit.app</contact>."
+    }
+  },
   "Expenses": {
     "title": "Dépenses",
     "description": "Voici les dépenses que vous avez créées pour votre groupe.",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -57,6 +57,30 @@ const nextConfig = {
       },
     ]
   },
+  async headers() {
+    return [
+      {
+        /**
+         * The Apple App Site Association file has no extension, so the static
+         * handler falls back to `application/octet-stream` and iOS discards it
+         * without a word. Universal Links only work when it arrives as JSON.
+         */
+        source: '/.well-known/apple-app-site-association',
+        headers: [{ key: 'Content-Type', value: 'application/json' }],
+      },
+    ]
+  },
+  async redirects() {
+    return [
+      // `/privacy` is the address the iOS app's documentation hands out; the
+      // page itself has lived at `/privacy-policy` since the first listing.
+      {
+        source: '/privacy',
+        destination: '/privacy-policy',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 export default withAxiom(withNextIntl(nextConfig))

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["VKY5EKKU47.app.spliit.spliitmobile"],
+        "components": [
+          {
+            "/": "/groups/*",
+            "comment": "Opens a group in the iOS app"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -188,6 +188,11 @@ function Content({ children }: { children: React.ReactNode }) {
                 </Button>
               </FeedbackModal>
             </span>
+            <span>
+              <Button variant="link" size="sm" asChild className="-ml-3 h-7">
+                <Link href="/privacy-policy">{t('PrivacyPolicy.title')}</Link>
+              </Button>
+            </span>
           </div>
         </div>
         <div>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,103 +1,130 @@
-/* eslint-disable react/no-unescaped-entities */
+import { getAnalyticsConfig } from '@/lib/analytics/config'
+import { TrackPage } from '@/lib/analytics/track-page'
+import { getRuntimeFeatureFlags } from '@/lib/featureFlags'
+import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
+import { ReactNode } from 'react'
 
-export default function PrivacyPolicy() {
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('PrivacyPolicy')
+  return {
+    title: t('title'),
+    description: t('metaDescription'),
+  }
+}
+
+/**
+ * What this page may truthfully say depends on how the instance serving it is
+ * configured: receipt scanning is only a disclosure worth making where an
+ * OpenAI key exists, and a self-hosted instance with no analytics provider must
+ * not claim to send anything anywhere. Both are read per request, as the layout
+ * already does for the analytics script itself.
+ */
+export default async function PrivacyPolicy() {
+  const t = await getTranslations('PrivacyPolicy')
+  const {
+    enableExpenseDocuments,
+    enableReceiptExtract,
+    enableCategoryExtract,
+  } = await getRuntimeFeatureFlags()
+  const { provider } = await getAnalyticsConfig()
+
+  // The `console` provider only prints events to the browser console, so
+  // nothing leaves the device and there is nothing to disclose.
+  const sendsAnalytics = provider === 'plausible'
+  const usesAI = enableReceiptExtract || enableCategoryExtract
+
+  const contact = (chunks: ReactNode) => (
+    <a href="mailto:hello@spliit.app">{chunks}</a>
+  )
+
   return (
-    <div className="prose prose-sm sm:prose-md md:prose-lg dark:prose-invert mx-auto pt-8 px-4">
-      <h1>Privacy Policy</h1>
+    <article className="prose prose-sm sm:prose-base dark:prose-invert mx-auto pt-8 pb-16 px-4 [&_a]:text-primary">
+      <TrackPage path="/privacy-policy" />
+      <h1>{t('title')}</h1>
+      <p className="text-muted-foreground !mt-0">{t('lastUpdated')}</p>
       <p>
-        This privacy policy applies to the Spliit app (hereby referred to as
-        "Application") for mobile devices that was created by Sebastien Castiel
-        (hereby referred to as "Service Provider") as an Open Source service.
-        This service is intended for use "AS IS".
+        {t.rich('intro', {
+          link: (chunks) => (
+            <a href="https://spliit.app" target="_blank" rel="noopener">
+              {chunks}
+            </a>
+          ),
+        })}
       </p>
-      <h2>What information does the Application obtain and how is it used?</h2>
+
+      <h2>{t('noAccount.title')}</h2>
+      <p>{t('noAccount.body')}</p>
+
+      <h2>{t('whatIsStored.title')}</h2>
+      <p>{t('whatIsStored.body')}</p>
+      {enableExpenseDocuments && <p>{t('whatIsStored.documents')}</p>}
+
+      <h2>{t('groupLinks.title')}</h2>
+      <p>{t('groupLinks.body')}</p>
+
+      <h2>{t('onYourDevice.title')}</h2>
+      <p>{t('onYourDevice.body')}</p>
+
+      <h2>{t('analytics.title')}</h2>
+      {sendsAnalytics ? (
+        <>
+          <p>{t('analytics.provider')}</p>
+          <p>
+            {t.rich('analytics.noIds', {
+              code: (chunks) => <code>{chunks}</code>,
+            })}
+          </p>
+        </>
+      ) : (
+        <p>{t('analytics.disabled')}</p>
+      )}
+      <p>{t('analytics.noTracking')}</p>
+
+      {usesAI && (
+        <>
+          <h2>{t('ai.title')}</h2>
+          {enableReceiptExtract && <p>{t('ai.receipt')}</p>}
+          {enableCategoryExtract && <p>{t('ai.category')}</p>}
+          <p>{t('ai.training')}</p>
+        </>
+      )}
+
+      <h2>{t('logs.title')}</h2>
+      <p>{t('logs.body')}</p>
+
+      <h2>{t('cookies.title')}</h2>
+      <p>{t('cookies.body')}</p>
+
+      <h2>{t('deleting.title')}</h2>
+      <p>{t.rich('deleting.body', { contact })}</p>
+
+      <h2>{t('children.title')}</h2>
+      <p>{t.rich('children.body', { contact })}</p>
+
+      <h2>{t('security.title')}</h2>
+      <p>{t('security.body')}</p>
+
+      <h2>{t('selfHosting.title')}</h2>
+      <p>{t('selfHosting.body')}</p>
+
+      <h2>{t('changes.title')}</h2>
       <p>
-        The Application does not obtain any information when you download and
-        use it. Registration is not required to use the Application.
+        {t.rich('changes.body', {
+          repository: (chunks) => (
+            <a
+              href="https://github.com/spliit-app/spliit-web"
+              target="_blank"
+              rel="noopener"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
       </p>
-      <h2>
-        Does the Application collect precise real time location information of
-        the device?
-      </h2>
-      <p>
-        This Application does not collect precise information about the location
-        of your mobile device.
-      </p>
-      <h2>
-        Do third parties see and/or have access to information obtained by the
-        Application?
-      </h2>
-      <p>
-        Since the Application does not collect any information, no data is
-        shared with third parties.
-      </p>
-      <h2>What are my opt-out rights?</h2>
-      <p>
-        You can stop all collection of information by the Application easily by
-        uninstalling it. You may use the standard uninstall processes as may be
-        available as part of your mobile device or via the mobile application
-        marketplace or network.
-      </p>
-      <h2>Children</h2>
-      <p>
-        The Application is not used to knowingly solicit data from or market to
-        children under the age of 13.
-      </p>
-      <p>
-        The Service Provider does not knowingly collect personally identifiable
-        information from children. The Service Provider encourages all children
-        to never submit any personally identifiable information through the
-        Application and/or Services. The Service Provider encourage parents and
-        legal guardians to monitor their children's Internet usage and to help
-        enforce this Policy by instructing their children never to provide
-        personally identifiable information through the Application and/or
-        Services without their permission. If you have reason to believe that a
-        child has provided personally identifiable information to the Service
-        Provider through the Application and/or Services, please contact the
-        Service Provider (hello@spliit.app) so that they will be able to take
-        the necessary actions. You must also be at least 16 years of age to
-        consent to the processing of your personally identifiable information in
-        your country (in some countries we may allow your parent or guardian to
-        do so on your behalf).
-      </p>
-      <h2>Security</h2>
-      <p>
-        The Service Provider is concerned about safeguarding the confidentiality
-        of your information. However, since the Application does not collect any
-        information, there is no risk of your data being accessed by
-        unauthorized individuals.
-      </p>
-      <h2>Changes</h2>
-      <p>
-        This Privacy Policy may be updated from time to time for any reason. The
-        Service Provider will notify you of any changes to their Privacy Policy
-        by updating this page with the new Privacy Policy. You are advised to
-        consult this Privacy Policy regularly for any changes, as continued use
-        is deemed approval of all changes.
-      </p>
-      <p>This privacy policy is effective as of 2024-11-07</p>
-      <h2>Your Consent</h2>
-      <p>
-        By using the Application, you are consenting to the processing of your
-        information as set forth in this Privacy Policy now and as amended by
-        the Service Provider.
-      </p>
-      <h2>Contact Us</h2>
-      <p>
-        If you have any questions regarding privacy while using the Application,
-        or have questions about the practices, please contact the Service
-        Provider via email at hello@spliit.app.
-      </p>
-      <p className="italic">
-        This privacy policy page was generated by{' '}
-        <a
-          href="https://app-privacy-policy-generator.nisrulz.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          App Privacy Policy Generator
-        </a>
-      </p>
-    </div>
+
+      <h2>{t('contact.title')}</h2>
+      <p>{t.rich('contact.body', { contact })}</p>
+    </article>
   )
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'yearly',
       priority: 1,
     },
+    {
+      url: `${env.NEXT_PUBLIC_BASE_URL}/privacy-policy`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
     ...posts.map(
       (post) =>
         ({


### PR DESCRIPTION
§8 of [spliit-ios#28](https://github.com/spliit-app/spliit-ios/pull/28) leaves two items on this repo's doorstep. Both are here.

## The privacy policy

App Store Connect will not take a submission without the URL, and §7 of the metadata says there is no page to point at. There is — `/privacy-policy`, unlinked from anywhere, generated in 2024 by [a boilerplate generator](https://app-privacy-policy-generator.nisrulz.com/). The problem is what it says:

> The Application does not obtain any information when you download and use it.
>
> Since the Application does not collect any information, no data is shared with third parties.

Neither survives contact with the code. Groups, participants, expense titles and amounts are stored on the server. Page views and a dozen events go to Plausible. A scanned receipt is sent to OpenAI, and so is an expense title when the app suggests a category. §6 of the metadata files App Privacy answers that say so — and a listing whose answers contradict the page they link to is a listing that disagrees with itself.

So the page is rewritten around what the code does, read rather than remembered: `anonymize-path.ts` for what analytics never sees, `events.ts` for what it does, the two OpenAI actions, `recent-groups-helpers.ts` for what stays in `localStorage`, and the absence of any group-delete procedure for the paragraph that admits a group can only be deleted by writing in.

**It is no longer English-only.** The listing ships in en-US and fr-FR, App Store Connect takes a policy URL *per localization*, and the locale here is a cookie falling back to `Accept-Language`. So one URL answers both, and §7's open question about where the French page lives does not need answering. The other 21 locales fall back to English until someone translates them.

**It tells the truth on instances that are not spliit.app.** The page is served by every self-hosted deployment too, and it has no business reciting our disclosures. An instance with no `ANALYTICS_PROVIDER` says it collects nothing rather than describing Plausible; receipt scanning is disclosed only where an OpenAI key exists; attached documents only where they are enabled.

| Section | Shown when |
|---|---|
| Analytics — Plausible, and the IDs stripped before sending | `ANALYTICS_PROVIDER=plausible` |
| Analytics — "collects no usage statistics at all" | otherwise |
| Scanning receipts / suggesting categories | `NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT` / `..._CATEGORY_EXTRACT` |
| Receipts stored with the file storage | `NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS` |

The `console` analytics provider counts as off: it prints to the browser console, so nothing leaves the device and there is nothing to disclose.

Finally, the page was reachable only by typing its address — a poor answer to give App Review. It is now a footer link and a sitemap entry.

## Universal Links

`public/.well-known/apple-app-site-association` names `VKY5EKKU47.app.spliit.spliitmobile` for `/groups/*`, per `Docs/universal-links.md`. The `Content-Type` header matters more than it looks: the file has no extension, the static handler falls back to `application/octet-stream`, and iOS drops it without a word — so `headers()` pins it to `application/json`.

`/privacy` also redirects to `/privacy-policy`, since `/privacy` is the address the iOS documentation hands out.

## The URL to paste into App Store Connect

`https://spliit.app/privacy-policy` — the same one for both localizations. Worth keeping over `/privacy` because the current 1.2.0 listing already points there, and 2.0.0 replaces that listing in place.

## Still not decided here

- **`PrivacyInfo.xcprivacy` still declares only Product Interaction.** This page now describes group data reaching the server, which is the answer §6 argues for. The manifest is in the iOS repo and still needs to agree.
- **The contact address is `hello@spliit.app`**, the one the old page already used. §7 left it as `<contact address>`.
- **"OpenAI does not train on this."** Stated as being under the terms of their API, which is accurate for API traffic, but it is a claim about a third party and worth a glance before it ships.
- **Nobody qualified has signed this off.** It is a careful description of behaviour, not legal advice — the same caveat §7 attached to its draft.

## Checks

`next build`, `tsc --noEmit` (0 errors) and 101 tests pass. Both languages render, as do both analytics configurations. Against `next start`:

```
GET /.well-known/apple-app-site-association  200, Content-Type: application/json, no redirect
GET /privacy                                 308 → /privacy-policy
GET /privacy-policy                          200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QawJut2CA7Da7vWQfLj4X3
