### PR TITLE
Do not emit standalone output on Vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,7 +32,16 @@ const nextConfig = {
   // Emit a self-contained server into .next/standalone, containing only the
   // files Next.js traced as actually reachable at runtime. The Docker runtime
   // stage copies that instead of a full production `node_modules`.
-  output: 'standalone',
+  //
+  // Everywhere except Vercel, which packages the app itself: there Next.js
+  // hands the build to Vercel's adapter (`Running onBuildComplete from
+  // Vercel`), and the standalone step runs right afterwards and reads
+  // `.next/next-server.js.nft.json` with no error handling. That file is gone
+  // by the time it looks, so the deployment dies on
+  // `ENOENT ... .next/next-server.js.nft.json` after an otherwise successful
+  // build. Vercel serves the adapter's output and never reads
+  // .next/standalone, so there is nothing to lose by not emitting it.
+  output: process.env.VERCEL ? undefined : 'standalone',
   images: {
     remotePatterns,
   },


### PR DESCRIPTION
## The failure

Deployments have been failing since the 1.23.x base sync. The Next.js build itself succeeds — every route compiles and prerenders — and then it dies at the very last step:

```
Running onBuildComplete from Vercel
> Build error occurred
Error: ENOENT: no such file or directory, open '/vercel/path0/.next/next-server.js.nft.json'
  errno: -2, code: 'ENOENT', syscall: 'open',
  path: '/vercel/path0/.next/next-server.js.nft.json'
```

## Cause

The base sync brought in `output: 'standalone'` (upstream #592, "build: standalone runtime image"), which exists so the Docker runtime stage can copy a traced, self-contained server instead of a full production `node_modules`. That is the right thing for the image, and the wrong thing on Vercel.

On Vercel, Next.js hands the finished build to Vercel's build adapter — the `Running onBuildComplete from Vercel` line — which packages the app from the traced output. In `next/dist/build/index.js`, the standalone step runs immediately *after* that adapter hook, and `copyTracedFiles` re-reads `.next/next-server.js.nft.json` with a bare `fs.readFile` and no error handling. By then the file is gone, and the raw ENOENT takes down an otherwise successful build.

The error surfaces as a top-level `> Build error occurred` rather than `Failed to run onBuildComplete from Vercel`, which places the throw *after* the adapter hook — i.e. in the standalone step, not inside Vercel's code. Next.js flags the conflict in its own source, right above the adapter call:

> This should come after `output: export` handling but before `output: standalone`, in the future `output: standalone` might not be allowed if an adapter with `onBuildComplete` is configured

## Fix

Emit standalone output everywhere except Vercel. Vercel serves the adapter's output and never looks at `.next/standalone`, so there is nothing to lose by not producing it there. The Docker image — the only consumer of the standalone server — is untouched.

## Verification

Built the real app locally on both paths (Next 16.3.3, Turbopack):

| | build | `.next/standalone` | `.next/next-server.js.nft.json` |
|---|---|---|---|
| `VERCEL=1` | ✅ exit 0 | not emitted | present |
| unset (Docker/local) | ✅ exit 0 | emitted | present |

No Next.js config warnings in either case. `tsc --noEmit` ✅, `prettier -c` ✅, `jest` ✅ 167/167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
