### PR TITLE
Display the standard iOS Smart App Banner

### DIFF
--- a/src/app/groups/[groupId]/layout.tsx
+++ b/src/app/groups/[groupId]/layout.tsx
@@ -1,4 +1,6 @@
 import { cached } from '@/app/cached-functions'
+import { appStore } from '@/lib/app-store'
+import { effectiveBaseUrl } from '@/lib/env'
 import { Metadata } from 'next'
 import { PropsWithChildren } from 'react'
 import { GroupLayoutClient } from './layout.client'
@@ -17,6 +19,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: {
       default: group?.name ?? '',
       template: `%s · ${group?.name} · Spliit`,
+    },
+    // The iOS app claims `/groups/*` as Universal Links, so the Smart App
+    // Banner hands it this group's URL: tapping “Open” lands on the group
+    // rather than on the app's home screen. Repeats `appId` because a child
+    // segment replaces the root layout's `itunes` object rather than merging
+    // into it.
+    itunes: {
+      appId: appStore.id,
+      appArgument: `${effectiveBaseUrl}/groups/${groupId}`,
     },
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/toaster'
 import { Analytics } from '@/lib/analytics/analytics'
 import { getAnalyticsConfig } from '@/lib/analytics/config'
+import { appStore } from '@/lib/app-store'
 import { effectiveBaseUrl } from '@/lib/env'
 import { TRPCProvider } from '@/trpc/client'
 import { HeartFilledIcon } from '@radix-ui/react-icons'
@@ -53,6 +54,11 @@ export async function generateMetadata(): Promise<Metadata> {
     appleWebApp: {
       capable: true,
       title: 'Spliit',
+    },
+    // Renders the standard iOS Smart App Banner in Safari, offering the native
+    // app to visitors browsing the website on an iPhone or iPad.
+    itunes: {
+      appId: appStore.id,
     },
     applicationName: 'Spliit',
     icons: [

--- a/src/components/news-button.tsx
+++ b/src/components/news-button.tsx
@@ -20,6 +20,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { useAnalytics } from '@/lib/analytics/context'
+import { appStore } from '@/lib/app-store'
 import { useLocalStorageState, useMediaQuery } from '@/lib/hooks'
 import { openCollective } from '@/lib/opencollective'
 // lucide-react v1 dropped its brand icons, so the social marks come from Radix.
@@ -126,11 +127,7 @@ const news: News[] = [
         </p>
         <p className="flex items-center gap-2">
           <Button asChild>
-            <a
-              target="_blank"
-              href="https://apps.apple.com/us/app/spliit-shares-expenses/id6737742507"
-              className="no-underline"
-            >
+            <a target="_blank" href={appStore.url} className="no-underline">
               <ExternalLink className="mr-2 w-4" />
               Download on App Store
             </a>

--- a/src/lib/app-store.ts
+++ b/src/lib/app-store.ts
@@ -1,0 +1,10 @@
+const APP_STORE_ID = '6737742507'
+
+/**
+ * Spliit’s iOS app on the App Store. Hardcoded rather than configurable: it
+ * points at the official app, not at whoever runs a given instance.
+ */
+export const appStore = {
+  id: APP_STORE_ID,
+  url: `https://apps.apple.com/us/app/spliit-shares-expenses/id${APP_STORE_ID}`,
+} as const


### PR DESCRIPTION
Safari on iOS shows a native "Smart App Banner" offering the app when a page carries the `apple-itunes-app` meta tag. Next's `itunes` metadata renders it from the root layout, so it appears on every page:

```html
<meta name="apple-itunes-app" content="app-id=6737742507"/>
```

On group pages it also carries `app-argument`, so tapping "Open" lands on the group rather than the app's home screen — `public/.well-known/apple-app-site-association` already claims `/groups/*` as Universal Links:

```html
<meta name="apple-itunes-app" content="app-id=6737742507, app-argument=https://spliit.app/groups/<id>"/>
```

`appId` is repeated in the group layout because a child segment replaces the root layout's `itunes` object rather than merging into it. Pages outside `/groups/*` keep the plain banner — the app claims no other paths, so there is nothing to hand over.

The App Store ID now lives in `src/lib/app-store.ts` alongside the store URL, following the `opencollective.ts` pattern, so the banner and the existing "Download on App Store" link in the news popover cannot drift apart.

## Verification

Ran the dev server and confirmed the rendered tag:

- `/`, `/blog` — `content="app-id=6737742507"`
- `/groups/<id>` — `content="app-id=6737742507, app-argument=<base>/groups/<id>"`

`npm test` passes (167 tests, 12 suites), `tsc --noEmit` is clean, and lint and Prettier report no new issues on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmNUikjDBgpxkkDxtEPnn5